### PR TITLE
fix: parse numeric string values for table chart metric column format…

### DIFF
--- a/components/charts/TableChart.tsx
+++ b/components/charts/TableChart.tsx
@@ -173,7 +173,7 @@ export function TableChart({
     // - decimalPlaces is specified AND no type is specified (for pure decimal formatting)
     // Also handles numeric strings from aggregated metric columns (e.g. backend returns "6500000")
     if (numberFormat || (decimalPlaces !== undefined && !type)) {
-      const numericValue = typeof value === 'number' ? value : Number(value);
+      const numericValue = Number(value);
       if (!isNaN(numericValue)) {
         const formatted = formatNumber(numericValue, {
           format: numberFormat || 'default',

--- a/components/charts/TableChart.tsx
+++ b/components/charts/TableChart.tsx
@@ -171,10 +171,11 @@ export function TableChart({
     // Use formatNumber path when:
     // - numberFormat is explicitly specified, OR
     // - decimalPlaces is specified AND no type is specified (for pure decimal formatting)
-    // Only format actual numeric values (typeof === 'number'), don't parse strings
+    // Also handles numeric strings from aggregated metric columns (e.g. backend returns "6500000")
     if (numberFormat || (decimalPlaces !== undefined && !type)) {
-      if (typeof value === 'number' && !isNaN(value)) {
-        const formatted = formatNumber(value, {
+      const numericValue = typeof value === 'number' ? value : Number(value);
+      if (!isNaN(numericValue)) {
+        const formatted = formatNumber(numericValue, {
           format: numberFormat || 'default',
           decimalPlaces: decimalPlaces,
         });


### PR DESCRIPTION
## Summary
- Table chart metric columns (SUM, COUNT, AVG, etc.) were not applying 
  number formatting in production because the backend returns aggregated 
  values as strings ("6500000") instead of numbers (6500000)
- Fixed by parsing numeric string values to number before applying 
  formatNumber when formatting is configured for a column


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved numeric formatting in table charts to also recognize numeric strings (such as values from aggregated metric columns) as numbers. Formatted output remains consistent with existing prefix/suffix and fallback behavior, ensuring numeric values from varied sources display correctly and consistently in tables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->