### PR TITLE
use public reports api for filter preview

### DIFF
--- a/components/dashboard/dashboard-filter-widgets.tsx
+++ b/components/dashboard/dashboard-filter-widgets.tsx
@@ -27,6 +27,7 @@ interface FilterWidgetProps {
   compact?: boolean;
   isPublicMode?: boolean;
   publicToken?: string;
+  isReportMode?: boolean;
   isLocked?: boolean;
 }
 
@@ -39,6 +40,7 @@ function ValueFilterWidget({
   isEditMode = false,
   isPublicMode = false,
   publicToken,
+  isReportMode = false,
 }: FilterWidgetProps) {
   const valueFilter = filter as ValueFilterConfig;
   const [selectedValues, setSelectedValues] = useState<string[]>(
@@ -53,11 +55,13 @@ function ValueFilterWidget({
     }
   }, [value, selectedValues, filter.id]);
 
-  // Build API URL based on public mode - now both use the preview endpoint format
+  // Build API URL based on public mode
   const apiUrl =
     filter.schema_name && filter.table_name && filter.column_name
       ? isPublicMode && publicToken
-        ? `/api/v1/public/dashboards/${publicToken}/filters/preview/?schema_name=${encodeURIComponent(filter.schema_name)}&table_name=${encodeURIComponent(filter.table_name)}&column_name=${encodeURIComponent(filter.column_name)}&filter_type=value&limit=100`
+        ? isReportMode
+          ? `/api/v1/public/reports/${publicToken}/filters/preview/?schema_name=${encodeURIComponent(filter.schema_name)}&table_name=${encodeURIComponent(filter.table_name)}&column_name=${encodeURIComponent(filter.column_name)}&filter_type=value&limit=100`
+          : `/api/v1/public/dashboards/${publicToken}/filters/preview/?schema_name=${encodeURIComponent(filter.schema_name)}&table_name=${encodeURIComponent(filter.table_name)}&column_name=${encodeURIComponent(filter.column_name)}&filter_type=value&limit=100`
         : `/api/filters/preview/?schema_name=${encodeURIComponent(filter.schema_name)}&table_name=${encodeURIComponent(filter.table_name)}&column_name=${encodeURIComponent(filter.column_name)}&filter_type=value&limit=100`
       : null;
 
@@ -226,6 +230,7 @@ function NumericalFilterWidget({
   isEditMode = false,
   isPublicMode = false,
   publicToken,
+  isReportMode = false,
 }: FilterWidgetProps) {
   const numericalFilter = filter as NumericalFilterConfig;
 
@@ -239,11 +244,13 @@ function NumericalFilterWidget({
   // Default ui_mode to SLIDER if not specified
   const uiMode = numericalFilter.settings.ui_mode || NumericalFilterUIMode.SLIDER;
 
-  // Build API URL based on public mode for numerical stats - now both use the preview endpoint format
+  // Build API URL based on public mode for numerical stats
   const numericalApiUrl =
     filter.schema_name && filter.table_name && filter.column_name
       ? isPublicMode && publicToken
-        ? `/api/v1/public/dashboards/${publicToken}/filters/preview/?schema_name=${encodeURIComponent(filter.schema_name)}&table_name=${encodeURIComponent(filter.table_name)}&column_name=${encodeURIComponent(filter.column_name)}&filter_type=numerical&limit=100`
+        ? isReportMode
+          ? `/api/v1/public/reports/${publicToken}/filters/preview/?schema_name=${encodeURIComponent(filter.schema_name)}&table_name=${encodeURIComponent(filter.table_name)}&column_name=${encodeURIComponent(filter.column_name)}&filter_type=numerical&limit=100`
+          : `/api/v1/public/dashboards/${publicToken}/filters/preview/?schema_name=${encodeURIComponent(filter.schema_name)}&table_name=${encodeURIComponent(filter.table_name)}&column_name=${encodeURIComponent(filter.column_name)}&filter_type=numerical&limit=100`
         : `/api/filters/preview/?schema_name=${encodeURIComponent(filter.schema_name)}&table_name=${encodeURIComponent(filter.table_name)}&column_name=${encodeURIComponent(filter.column_name)}&filter_type=numerical&limit=100`
       : null;
 

--- a/components/dashboard/filter-element.tsx
+++ b/components/dashboard/filter-element.tsx
@@ -19,6 +19,7 @@ interface FilterElementProps {
   dragHandleProps?: Record<string, unknown>; // DnD Kit listeners for drag handle
   isPublicMode?: boolean;
   publicToken?: string;
+  isReportMode?: boolean;
 }
 
 export function FilterElement({
@@ -34,6 +35,7 @@ export function FilterElement({
   dragHandleProps,
   isPublicMode = false,
   publicToken,
+  isReportMode = false,
 }: FilterElementProps) {
   // Check if filter is locked (e.g., date filter in report mode)
   const isLocked = !!(filter?.settings as any)?.locked;
@@ -146,6 +148,7 @@ export function FilterElement({
         compact={compact}
         isPublicMode={isPublicMode}
         publicToken={publicToken}
+        isReportMode={isReportMode}
         isLocked={isLocked}
       />
     </div>

--- a/components/dashboard/unified-filters-panel.tsx
+++ b/components/dashboard/unified-filters-panel.tsx
@@ -63,6 +63,7 @@ interface SortableFilterItemProps {
   layout: 'vertical' | 'horizontal';
   isPublicMode?: boolean;
   publicToken?: string;
+  isReportMode?: boolean;
 }
 
 function SortableFilterItem({
@@ -75,6 +76,7 @@ function SortableFilterItem({
   layout,
   isPublicMode = false,
   publicToken,
+  isReportMode = false,
 }: SortableFilterItemProps) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: filter.id,
@@ -103,6 +105,7 @@ function SortableFilterItem({
           onEdit={isEditMode ? () => onEdit?.(filter) : undefined}
           isPublicMode={isPublicMode}
           publicToken={publicToken}
+          isReportMode={isReportMode}
           isEditMode={isEditMode}
           showTitle={true}
           compact={true}
@@ -136,6 +139,7 @@ function SortableFilterItem({
         dragHandleProps={isEditMode ? listeners : undefined}
         isPublicMode={isPublicMode}
         publicToken={publicToken}
+        isReportMode={isReportMode}
       />
     </div>
   );
@@ -542,6 +546,7 @@ export function UnifiedFiltersPanel({
                           layout={layout}
                           isPublicMode={isPublicMode}
                           publicToken={publicToken}
+                          isReportMode={isReportMode}
                         />
                       ))}
                     </div>
@@ -679,6 +684,7 @@ export function UnifiedFiltersPanel({
                           layout={effectiveLayout}
                           isPublicMode={isPublicMode}
                           publicToken={publicToken}
+                          isReportMode={isReportMode}
                         />
                       ))}
                     </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added report mode support to filter widgets, enabling filters to function correctly in report contexts with public access. Filter components now intelligently route to the appropriate API endpoint based on the active mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->