### PR TITLE
wait till the public api hits before showing error state

### DIFF
--- a/components/dashboard/chart-element-view.tsx
+++ b/components/dashboard/chart-element-view.tsx
@@ -1628,6 +1628,8 @@ export function ChartElementView({
   if (
     isLoading ||
     (!isPublicMode && chartLoading) ||
+    // In public mode, wait for chart metadata to load before evaluating chart type or data
+    (isPublicMode && publicChartLoading) ||
     (isTableChart && tableLoading) ||
     (isMapChart && (mapLoading || geojsonLoading))
   ) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed loading state for public charts to ensure all metadata is fetched before rendering content, preventing incomplete chart display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->