### PR TITLE
remove unused onStateChange prop from CommentPopoverInner

### DIFF
--- a/components/reports/__tests__/comment-popover.test.tsx
+++ b/components/reports/__tests__/comment-popover.test.tsx
@@ -1,6 +1,4 @@
-/**
- * CommentPopover Tests
- *
+/*
  * Covers the two behavioral changes:
  * 1. markAsRead fires on open (not close)
  * 2. markAsRead fires after posting a new comment

--- a/components/reports/__tests__/comment-popover.test.tsx
+++ b/components/reports/__tests__/comment-popover.test.tsx
@@ -1,0 +1,110 @@
+/**
+ * CommentPopover Tests
+ *
+ * Covers the two behavioral changes:
+ * 1. markAsRead fires on open (not close)
+ * 2. markAsRead fires after posting a new comment
+ */
+
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { CommentPopover } from '../comment-popover';
+import * as useCommentsHook from '@/hooks/api/useComments';
+import { TestWrapper } from '@/test-utils/render';
+
+// ============ Mocks ============
+
+jest.mock('@/hooks/api/useComments');
+jest.mock('@/stores/authStore', () => ({
+  useAuthStore: (selector: (s: any) => any) =>
+    selector({ getCurrentOrgUser: () => ({ email: 'user@test.com' }) }),
+}));
+jest.mock('@/lib/toast', () => ({
+  toastError: { create: jest.fn() },
+}));
+jest.mock('@/hooks/useMentionInput', () => ({
+  useMentionInput: (): object => ({
+    text: 'Hello',
+    setText: jest.fn(),
+    showMentions: false,
+    mentionQuery: '',
+    highlightedIndex: -1,
+    setHighlightedIndex: jest.fn(),
+    handleChange: jest.fn(),
+    handleMentionSelect: jest.fn(),
+    closeMentions: jest.fn(),
+    inputRef: { current: null },
+  }),
+}));
+
+const mockMarkAsRead = jest.fn().mockResolvedValue(undefined);
+const mockCreateComment = jest.fn().mockResolvedValue({ id: 1 });
+const mockMutateComments = jest.fn().mockResolvedValue(undefined);
+
+function setupMocks() {
+  (useCommentsHook.useComments as jest.Mock).mockReturnValue({
+    comments: [],
+    isLoading: false,
+    isError: null,
+    mutate: mockMutateComments,
+  });
+  (useCommentsHook.useMentionableUsers as jest.Mock).mockReturnValue({ users: [] });
+  (useCommentsHook.markAsRead as jest.Mock) = mockMarkAsRead;
+  (useCommentsHook.createComment as jest.Mock) = mockCreateComment;
+}
+
+const renderPopover = () =>
+  render(
+    <TestWrapper>
+      <CommentPopover
+        snapshotId={1}
+        targetType="summary"
+        state="unread"
+        onStateChange={jest.fn()}
+      />
+    </TestWrapper>
+  );
+
+// ============ Tests ============
+
+describe('CommentPopover', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setupMocks();
+  });
+
+  describe('Mark as read on open', () => {
+    it('calls markAsRead when popover is opened', async () => {
+      const user = userEvent.setup();
+      renderPopover();
+
+      await user.click(screen.getByRole('button'));
+
+      await waitFor(() => {
+        expect(mockMarkAsRead).toHaveBeenCalledWith(1, {
+          target_type: 'summary',
+          chart_id: undefined,
+        });
+      });
+    });
+  });
+
+  describe('Mark as read after posting a comment', () => {
+    it('calls markAsRead after submitting a comment', async () => {
+      const user = userEvent.setup();
+      renderPopover();
+
+      await user.click(screen.getByRole('button')); // open
+      mockMarkAsRead.mockClear(); // ignore open-time call
+
+      const submitBtn = await screen.findByTestId('comment-submit-btn');
+      await user.click(submitBtn);
+
+      await waitFor(() => {
+        expect(mockCreateComment).toHaveBeenCalled();
+        expect(mockMarkAsRead).toHaveBeenCalled();
+      });
+    });
+  });
+});

--- a/components/reports/comment-popover.tsx
+++ b/components/reports/comment-popover.tsx
@@ -546,16 +546,12 @@ function CommentPopoverInner({
     return () => clearTimeout(timer);
   }, [open, comments.length]);
 
-  // Mark as read on close
+  // Mark as read on open (like LinkedIn/Slack — notifications clear when you open the panel)
   const handleOpenChange = useCallback(
     async (isOpen: boolean) => {
       setOpen(isOpen);
-      if (!isOpen) {
-        // Reset state
-        setDraft('');
-        closeMentions();
-
-        // Mark as read
+      if (isOpen) {
+        // Mark as read immediately when popover opens so the dot clears while user is reading
         try {
           await markAsRead(snapshotId, {
             target_type: targetType,
@@ -565,6 +561,10 @@ function CommentPopoverInner({
         } catch {
           // Silent fail for mark-as-read
         }
+      } else {
+        // Reset draft state on close
+        setDraft('');
+        closeMentions();
       }
     },
     [snapshotId, targetType, chartId, onStateChange, setDraft, closeMentions]
@@ -585,6 +585,14 @@ function CommentPopoverInner({
       });
       setDraft('');
       await mutateComments();
+      // New comment is created with is_new: true — mark as read immediately so
+      // the icon shows outline dot (read) instead of filled red dot (unread)
+      try {
+        await markAsRead(snapshotId, { target_type: targetType, chart_id: chartId });
+      } catch {
+        // Silent fail
+      }
+      onStateChange?.();
       setTimeout(() => {
         bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
       }, SCROLL_DELAY_MS);
@@ -593,7 +601,16 @@ function CommentPopoverInner({
     } finally {
       setIsSubmitting(false);
     }
-  }, [draft, isSubmitting, snapshotId, targetType, chartId, mutateComments, setDraft]);
+  }, [
+    draft,
+    isSubmitting,
+    snapshotId,
+    targetType,
+    chartId,
+    mutateComments,
+    onStateChange,
+    setDraft,
+  ]);
 
   // Keyboard: Arrow keys for mention navigation, Enter to select/submit, Escape to close
   const handleKeyDown = useCallback(

--- a/components/reports/comment-popover.tsx
+++ b/components/reports/comment-popover.tsx
@@ -585,7 +585,6 @@ function CommentPopoverInner({
       });
       setDraft('');
       await mutateComments();
-      onStateChange?.();
       setTimeout(() => {
         bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
       }, SCROLL_DELAY_MS);
@@ -594,16 +593,7 @@ function CommentPopoverInner({
     } finally {
       setIsSubmitting(false);
     }
-  }, [
-    draft,
-    isSubmitting,
-    snapshotId,
-    targetType,
-    chartId,
-    mutateComments,
-    onStateChange,
-    setDraft,
-  ]);
+  }, [draft, isSubmitting, snapshotId, targetType, chartId, mutateComments, setDraft]);
 
   // Keyboard: Arrow keys for mention navigation, Enter to select/submit, Escape to close
   const handleKeyDown = useCallback(


### PR DESCRIPTION
Problem
Two related issues with the comment icon dot:

After submitting a comment, the icon immediately showed a filled red dot (unread) even though the user just wrote it themselves — misleading UI
When opening the popover to read unread comments, the filled red dot stayed visible the entire time you were reading — it only cleared after closing. This is wrong behavior compared to platforms like LinkedIn/Slack where notifications clear the moment you open them
Root Cause

Issue 1: handleSubmit was calling onStateChange() right after creating a comment. This re-fetched the icon state from the backend, which returned unread because every new comment has is_new: true for all users including the author.

Issue 2: markAsRead() was only being called on popover close — meaning the filled red dot stayed visible the whole time the user was reading comments.

Fix

Moved markAsRead() to popover open — dot clears immediately when user opens the popover, not after closing
Added markAsRead() in handleSubmit — called before onStateChange() so the backend returns read instead of unread after submitting your own comment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed comment submission to mark newly created comments as read immediately upon creation.
  * Improved comment popover state management for better handling of drafts and mentions when opening and closing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->