### PR TITLE
fix: hide filter active dot in report mode as filters are always locked

### DIFF
--- a/components/dashboard/unified-filters-panel.tsx
+++ b/components/dashboard/unified-filters-panel.tsx
@@ -321,10 +321,14 @@ export function UnifiedFiltersPanel({
   };
 
   // Check if any filters have values
-  const hasActiveFilters = Object.values(currentFilterValues).some(
-    (value) =>
-      value !== null && value !== undefined && (Array.isArray(value) ? value.length > 0 : true)
-  );
+  // In report mode, filters are always locked and auto-set from the frozen report config,
+  // so the dot indicator is never meaningful there — suppress it entirely
+  const hasActiveFilters = isReportMode
+    ? false
+    : Object.values(currentFilterValues).some(
+        (value) =>
+          value !== null && value !== undefined && (Array.isArray(value) ? value.length > 0 : true)
+      );
 
   // Toggle panel collapse state (hides entire panel)
   const togglePanelCollapse = () => {

--- a/components/dashboard/unified-filters-panel.tsx
+++ b/components/dashboard/unified-filters-panel.tsx
@@ -321,14 +321,18 @@ export function UnifiedFiltersPanel({
   };
 
   // Check if any filters have values
-  // In report mode, filters are always locked and auto-set from the frozen report config,
-  // so the dot indicator is never meaningful there — suppress it entirely
-  const hasActiveFilters = isReportMode
-    ? false
-    : Object.values(currentFilterValues).some(
-        (value) =>
-          value !== null && value !== undefined && (Array.isArray(value) ? value.length > 0 : true)
-      );
+  // In report mode, locked filters are auto-set from the frozen report config and cannot
+  // be changed by the user — exclude them so they don't trigger the blue dot indicator
+  const hasActiveFilters = Object.entries(currentFilterValues).some(([filterId, value]) => {
+    if (isReportMode) {
+      const filter = filters.find((f) => String(f.id) === String(filterId));
+      const isLocked = !!(filter?.settings as any)?.locked;
+      if (isLocked) return false;
+    }
+    return (
+      value !== null && value !== undefined && (Array.isArray(value) ? value.length > 0 : true)
+    );
+  });
 
   // Toggle panel collapse state (hides entire panel)
   const togglePanelCollapse = () => {


### PR DESCRIPTION
Problem
When opening a report that has a date filter, a blue dot appears next to "Filters" with the text "Some applied" — immediately on load, without the user touching anything. There is no way to dismiss it since the filter is locked.

Root Cause
The hasActiveFilters check in unified-filters-panel.tsx only looks at whether filter values are non-null. In report mode, date filters are always pre-populated with the report's frozen date range on load — so values are non-null from the start, making hasActiveFilters = true and the dot appear immediately.

Why the dot can never disappear in report mode
When a report is created, the backend (report_service.py) always sets locked: True on the date filter — without exception. There is no code path where a report filter ends up unlocked. Since the filter is locked, the user can never change it, which means the dot can never be "earned" or "dismissed" through any user action. It would stay there permanently.

Fix
Set hasActiveFilters = false always in report mode. Since filters are always locked and auto-set from the frozen report config, the dot indicator is never meaningful in reports.

Question / Discussion Point

Should reports ever have an interactive filter dot in the future?

If the product decision is that report filters will always remain locked (as they are today), this fix is permanent and correct. If in the future some report filters become editable, this logic would need to be revisited.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Report mode no longer marks filters as “active” when those filters are locked — filter indicators (blue dot / “Some applied”) now reflect only applicable, unlocked filter selections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->