### PR TITLE
make sure dummy node doesn't collide

### DIFF
--- a/components/transform/ui-transform/canvas/Canvas.tsx
+++ b/components/transform/ui-transform/canvas/Canvas.tsx
@@ -141,6 +141,8 @@ export default function Canvas({ isPreviewMode = false, onRefresh }: CanvasProps
     lockUpperSection,
     isWorkflowRunning,
     canInteractWithCanvas,
+    fullLayoutRequested,
+    clearFullLayoutRequest,
   } = useTransformStore();
   const finalLockCanvas = tempLockCanvas || lockUpperSection;
 
@@ -162,6 +164,16 @@ export default function Canvas({ isPreviewMode = false, onRefresh }: CanvasProps
   // On incremental updates: run dagre on the full graph to get ideal positions for NEW nodes,
   // but preserve existing node positions so the canvas doesn't jump.
   const isFirstLoadRef = useRef(true);
+
+  useEffect(() => {
+    // When a full layout is requested (e.g. after saving an operation or creating a table),
+    // reset refs so the next data change triggers a full dagre layout instead of incremental.
+    if (fullLayoutRequested) {
+      isFirstLoadRef.current = true;
+      processedDataRef.current = '';
+      clearFullLayoutRequest();
+    }
+  }, [fullLayoutRequested, clearFullLayoutRequest]);
 
   useEffect(() => {
     const dataHash = JSON.stringify({

--- a/components/transform/ui-transform/canvas/forms/single-source/CreateTableForm.tsx
+++ b/components/transform/ui-transform/canvas/forms/single-source/CreateTableForm.tsx
@@ -44,7 +44,7 @@ const DEFAULT_SCHEMAS = ['intermediate', 'production'];
  * Allows specifying output name, destination schema, and directory.
  */
 export function CreateTableForm({ node, clearAndClosePanel, setLoading }: CreateTableFormProps) {
-  const { dispatchCanvasAction, triggerRefresh } = useTransformStore();
+  const { dispatchCanvasAction, triggerRefresh, requestFullLayout } = useTransformStore();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [directories, setDirectories] = useState<ComboboxItem[]>([]);
   const [schemas, setSchemas] = useState<ComboboxItem[]>([]);
@@ -198,6 +198,8 @@ export function CreateTableForm({ node, clearAndClosePanel, setLoading }: Create
       // Trigger workflow execution
       dispatchCanvasAction({ type: CanvasActionEnum.RUN_WORKFLOW, data: null });
 
+      // Request full dagre layout so the canvas recalculates all positions
+      requestFullLayout();
       // Refresh canvas
       triggerRefresh();
 

--- a/components/transform/ui-transform/canvas/layout/hooks/useDummyNodeManager.ts
+++ b/components/transform/ui-transform/canvas/layout/hooks/useDummyNodeManager.ts
@@ -25,12 +25,31 @@ export function useDummyNodeManager() {
       const dummyId = `dummy-${Date.now()}`;
       dummyNodeIdRef.current = dummyId;
 
-      // Use position stored on selectedNode (set during click, like v1's xPos/yPos).
-      // Fallback: look up position from React Flow state.
-      let sourcePosition = currentNode.position;
-      if (!sourcePosition) {
-        const flowNode = getNodes().find((n) => n.id === currentNode.id);
-        sourcePosition = flowNode?.position || { x: 0, y: 0 };
+      // Always read position from React Flow's live state to avoid stale values.
+      const allNodes = getNodes();
+      const flowNode = allNodes.find((n) => n.id === currentNode.id);
+      const sourcePosition = flowNode?.position || currentNode.position || { x: 0, y: 0 };
+
+      // Calculate target position to the right of the source node
+      let targetX = sourcePosition.x + CANVAS_CONSTANTS.DAGRE_RANK_SEP;
+      let targetY = sourcePosition.y;
+
+      // Check for collisions with existing nodes at the target position.
+      // When the user creates multiple operations from the same source node,
+      // each new dummy must be offset vertically to avoid overlapping with
+      // previously saved operation nodes.
+      const COLLISION_THRESHOLD_X = 150;
+      const COLLISION_THRESHOLD_Y = 150;
+      const VERTICAL_OFFSET = COLLISION_THRESHOLD_Y + 30;
+
+      for (const existingNode of allNodes) {
+        if (existingNode.id === currentNode.id) continue;
+        const dx = Math.abs(existingNode.position.x - targetX);
+        const dy = Math.abs(existingNode.position.y - targetY);
+        if (dx < COLLISION_THRESHOLD_X && dy < COLLISION_THRESHOLD_Y) {
+          // Collision detected — push dummy below the conflicting node
+          targetY = existingNode.position.y + VERTICAL_OFFSET;
+        }
       }
 
       // Position to the right of the source node, matching the LR dagre layout
@@ -38,8 +57,8 @@ export function useDummyNodeManager() {
         id: dummyId,
         type: CanvasNodeTypeEnum.Operation,
         position: {
-          x: sourcePosition.x + CANVAS_CONSTANTS.DAGRE_RANK_SEP,
-          y: sourcePosition.y,
+          x: targetX,
+          y: targetY,
         },
         data: {
           uuid: dummyId,

--- a/components/transform/ui-transform/canvas/panels/OperationConfigLayout.tsx
+++ b/components/transform/ui-transform/canvas/panels/OperationConfigLayout.tsx
@@ -52,7 +52,8 @@ export function OperationConfigLayout({ open, onClose }: OperationConfigLayoutPr
   const { mutate } = useSWRConfig();
   const selectedNode = useSelectedNode();
   const canvasAction = useCanvasAction();
-  const { closeOperationPanel, setSelectedNode, clearCanvasAction } = useTransformStore();
+  const { closeOperationPanel, setSelectedNode, clearCanvasAction, requestFullLayout } =
+    useTransformStore();
 
   // Dummy node management (create, cleanup, swap)
   const { dummyNodeIdRef, createDummyNode, cleanupDummyNodes, swapDummyForRealNode } =
@@ -207,10 +208,9 @@ export function OperationConfigLayout({ open, onClose }: OperationConfigLayoutPr
         cleanupDummyNodes();
       }
 
-      // Now refresh graph to get full node data from API.
-      // The real operation node is already on the canvas with the correct position,
-      // so Canvas.tsx's incremental update will preserve it via currentPosMap.
-      // Any new nodes (e.g. second table in union) get positioned via shift calculation.
+      // Request full dagre layout so the canvas recalculates all positions
+      // (prevents overlapping nodes that only resolve on browser refresh).
+      requestFullLayout();
       await mutate(CANVAS_GRAPH_KEY);
 
       // Small delay to allow React Flow to process the refreshed nodes

--- a/stores/transformStore.ts
+++ b/stores/transformStore.ts
@@ -46,8 +46,11 @@ interface TransformState {
   // === Canvas State ===
   refreshTrigger: number;
   isCanvasLoading: boolean;
+  fullLayoutRequested: boolean;
   triggerRefresh: () => void;
   setCanvasLoading: (loading: boolean) => void;
+  requestFullLayout: () => void;
+  clearFullLayoutRequest: () => void;
 
   // === Locking State ===
   lockUpperSection: boolean;
@@ -129,6 +132,7 @@ const initialState = {
 
   refreshTrigger: 0,
   isCanvasLoading: false,
+  fullLayoutRequested: false,
 
   lockUpperSection: false,
   tempLockCanvas: false,
@@ -181,6 +185,8 @@ export const useTransformStore = create<TransformState>()(
       // Canvas State
       triggerRefresh: () => set((state) => ({ refreshTrigger: state.refreshTrigger + 1 })),
       setCanvasLoading: (loading) => set({ isCanvasLoading: loading }),
+      requestFullLayout: () => set({ fullLayoutRequested: true }),
+      clearFullLayoutRequest: () => set({ fullLayoutRequested: false }),
 
       // Locking
       setLockUpperSection: (lock) => set({ lockUpperSection: lock }),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dummy node placement so new nodes are positioned using live graph state and automatically avoid collisions with existing nodes.
* **New Features**
  * Added a "full layout" request mechanism and updated canvas flows so certain create/replace operations trigger a full layout recalculation for consistent graph placement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->