### PR TITLE
fix: align report header layout and button styling with dashboard

### DIFF
--- a/app/reports/[snapshotId]/page.tsx
+++ b/app/reports/[snapshotId]/page.tsx
@@ -110,7 +110,7 @@ export default function SnapshotViewerPage() {
   return (
     <div className="flex flex-col h-full">
       {/* Header */}
-      <div className="flex-shrink-0 border-b bg-white shadow-sm px-6 py-4">
+      <div className="flex-shrink-0 border-b bg-background shadow-sm px-6 py-4">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-4 min-w-0 flex-1">
             <Button
@@ -123,9 +123,9 @@ export default function SnapshotViewerPage() {
               Back
             </Button>
             <div className="min-w-0 flex-1">
-              <h1 className="text-2xl font-bold text-gray-900">{report_metadata.title}</h1>
+              <h1 className="text-2xl font-bold text-foreground">{report_metadata.title}</h1>
               {/* Metadata below title */}
-              <div className="flex items-center gap-4 mt-2 text-xs text-gray-500">
+              <div className="flex items-center gap-4 mt-2 text-xs text-muted-foreground">
                 <span className="flex items-center gap-1">
                   <Calendar className="w-3 h-3" />
                   {report_metadata.period_start
@@ -179,7 +179,10 @@ export default function SnapshotViewerPage() {
             {canEdit && (
               <Button
                 data-testid="report-save-btn"
+                variant="ghost"
                 size="sm"
+                className="text-white hover:opacity-90 shadow-xs"
+                style={{ backgroundColor: 'var(--primary)' }}
                 onClick={handleSave}
                 disabled={isSaving}
               >

--- a/app/reports/[snapshotId]/page.tsx
+++ b/app/reports/[snapshotId]/page.tsx
@@ -176,19 +176,6 @@ export default function SnapshotViewerPage() {
             {canShare && currentUserEmail === report_metadata.created_by && (
               <ReportShareMenu snapshotId={parsedId} reportTitle={report_metadata.title} />
             )}
-            {canEdit && (
-              <Button
-                data-testid="report-save-btn"
-                variant="ghost"
-                size="sm"
-                className="text-white hover:opacity-90 shadow-xs"
-                style={{ backgroundColor: 'var(--primary)' }}
-                onClick={handleSave}
-                disabled={isSaving}
-              >
-                {isSaving ? 'Saving...' : 'Save'}
-              </Button>
-            )}
           </div>
         </div>
       </div>
@@ -254,6 +241,36 @@ export default function SnapshotViewerPage() {
                 rows={2}
                 className={`resize-y border-none shadow-none p-0 focus-visible:ring-0 text-sm text-muted-foreground placeholder:text-muted-foreground ${!isEditingSummary ? 'cursor-default' : ''}`}
               />
+              {canEdit && isEditingSummary && (
+                <div className="flex justify-end gap-2 mt-2">
+                  <Button
+                    data-testid="report-cancel-edit-btn"
+                    variant="ghost"
+                    size="sm"
+                    className="text-white hover:text-white hover:opacity-90 shadow-xs"
+                    style={{ backgroundColor: 'var(--destructive)' }}
+                    onClick={() => {
+                      setSummaryDraft(viewData?.report_metadata.summary || '');
+                      setSummaryTouched(false);
+                      setIsEditingSummary(false);
+                    }}
+                    disabled={isSaving}
+                  >
+                    Cancel
+                  </Button>
+                  <Button
+                    data-testid="report-save-btn"
+                    variant="ghost"
+                    size="sm"
+                    className="text-white hover:text-white hover:opacity-90 shadow-xs"
+                    style={{ backgroundColor: 'var(--primary)' }}
+                    onClick={handleSave}
+                    disabled={isSaving}
+                  >
+                    {isSaving ? 'Saving...' : 'Save'}
+                  </Button>
+                </div>
+              )}
             </div>
           }
         />

--- a/app/reports/[snapshotId]/page.tsx
+++ b/app/reports/[snapshotId]/page.tsx
@@ -110,77 +110,83 @@ export default function SnapshotViewerPage() {
   return (
     <div className="flex flex-col h-full">
       {/* Header */}
-      <div className="flex-shrink-0 border-b bg-background px-6 pt-4 pb-3">
-        {/* Top row: Back + Title + Actions */}
+      <div className="flex-shrink-0 border-b bg-white shadow-sm px-6 py-4">
         <div className="flex items-center justify-between">
-          <div className="flex items-center gap-3">
-            <button
-              type="button"
+          <div className="flex items-center gap-4 min-w-0 flex-1">
+            <Button
+              variant="ghost"
+              size="sm"
               data-testid="report-back-btn"
               onClick={() => router.push('/reports')}
-              className="flex items-center gap-1 text-sm text-foreground hover:text-primary"
             >
-              <ArrowLeft className="h-4 w-4" />
+              <ArrowLeft className="w-4 h-4 mr-2" />
               Back
-            </button>
-            <h1 className="text-2xl font-bold">{report_metadata.title}</h1>
+            </Button>
+            <div className="min-w-0 flex-1">
+              <h1 className="text-2xl font-bold text-gray-900">{report_metadata.title}</h1>
+              {/* Metadata below title */}
+              <div className="flex items-center gap-4 mt-2 text-xs text-gray-500">
+                <span className="flex items-center gap-1">
+                  <Calendar className="w-3 h-3" />
+                  {report_metadata.period_start
+                    ? formatDateShort(report_metadata.period_start)
+                    : 'All'}{' '}
+                  - {formatDateShort(report_metadata.period_end)}
+                </span>
+                {report_metadata.created_by && (
+                  <span className="flex items-center gap-1">
+                    <User className="w-3 h-3" />
+                    Created by: {report_metadata.created_by}
+                  </span>
+                )}
+                {report_metadata.dashboard_title &&
+                  (report_metadata.dashboard_id ? (
+                    <Link
+                      href={`/dashboards/${report_metadata.dashboard_id}`}
+                      className="flex items-center gap-1 hover:text-primary transition-colors"
+                      data-testid="report-dashboard-link"
+                    >
+                      <LayoutGrid className="w-3 h-3" />
+                      {report_metadata.dashboard_title}
+                    </Link>
+                  ) : (
+                    <span className="flex items-center gap-1">
+                      <LayoutGrid className="w-3 h-3" />
+                      {report_metadata.dashboard_title}
+                    </span>
+                  ))}
+              </div>
+            </div>
           </div>
-          <div className="flex items-center gap-2">
+          <div className="flex items-center gap-2 flex-shrink-0">
             <Button
               data-testid="report-download-btn"
-              variant="ghost"
-              size="icon"
+              variant="outline"
+              size="sm"
               aria-label="Download report as PDF"
               onClick={handleDownload}
               disabled={isExporting}
             >
               {isExporting ? (
-                <Loader2 className="h-4 w-4 animate-spin" />
+                <Loader2 className="w-4 h-4 animate-spin" />
               ) : (
-                <Download className="h-4 w-4" />
+                <Download className="w-4 h-4" />
               )}
             </Button>
             {canShare && currentUserEmail === report_metadata.created_by && (
               <ReportShareMenu snapshotId={parsedId} reportTitle={report_metadata.title} />
             )}
             {canEdit && (
-              <Button data-testid="report-save-btn" onClick={handleSave} disabled={isSaving}>
+              <Button
+                data-testid="report-save-btn"
+                size="sm"
+                onClick={handleSave}
+                disabled={isSaving}
+              >
                 {isSaving ? 'Saving...' : 'Save'}
               </Button>
             )}
           </div>
-        </div>
-
-        {/* Metadata row */}
-        <div className="flex items-center gap-4 mt-1 text-sm text-muted-foreground">
-          <span className="flex items-center gap-1.5">
-            <Calendar className="h-3.5 w-3.5" />
-            {report_metadata.period_start
-              ? formatDateShort(report_metadata.period_start)
-              : 'All'} - {formatDateShort(report_metadata.period_end)}
-          </span>
-          {report_metadata.created_by && (
-            <span className="flex items-center gap-1.5">
-              <User className="h-3.5 w-3.5" />
-              Created by: {report_metadata.created_by}
-            </span>
-          )}
-          {report_metadata.dashboard_title &&
-            (report_metadata.dashboard_id ? (
-              <Link
-                href={`/dashboards/${report_metadata.dashboard_id}`}
-                className="flex items-center gap-1.5 hover:text-primary transition-colors"
-                data-testid="report-dashboard-link"
-              >
-                <LayoutGrid className="h-3.5 w-3.5" />
-                {report_metadata.dashboard_title}
-              </Link>
-            ) : (
-              <span className="flex items-center gap-1.5">
-                <LayoutGrid className="h-3.5 w-3.5" />
-                {report_metadata.dashboard_title}
-              </span>
-            ))}
         </div>
       </div>
 

--- a/app/reports/[snapshotId]/page.tsx
+++ b/app/reports/[snapshotId]/page.tsx
@@ -64,6 +64,7 @@ export default function SnapshotViewerPage() {
     try {
       await updateSnapshot(parsedId, { summary: summaryDraft });
       mutate();
+      setSummaryTouched(false);
       setIsEditingSummary(false);
       toastSuccess.saved('Report');
     } catch (error) {

--- a/components/reports/__tests__/snapshot-viewer-page.test.tsx
+++ b/components/reports/__tests__/snapshot-viewer-page.test.tsx
@@ -244,11 +244,15 @@ describe('SnapshotViewerPage', () => {
       expect(textarea.value).toBe('This is the initial summary.');
     });
 
-    it('renders action buttons (download, share, save)', () => {
+    it('renders action buttons (download, share, save)', async () => {
+      const user = userEvent.setup();
       renderPage();
 
       expect(screen.getByTestId('report-download-btn')).toBeInTheDocument();
       expect(screen.getByTestId('report-share-btn')).toBeInTheDocument();
+
+      // Save button only appears after entering edit mode
+      await user.click(screen.getByTestId('summary-edit-btn'));
       expect(screen.getByTestId('report-save-btn')).toBeInTheDocument();
     });
   });
@@ -349,6 +353,7 @@ describe('SnapshotViewerPage', () => {
 
       renderPage();
 
+      await user.click(screen.getByTestId('summary-edit-btn'));
       const saveBtn = screen.getByTestId('report-save-btn');
       await user.click(saveBtn);
 
@@ -363,6 +368,7 @@ describe('SnapshotViewerPage', () => {
 
       renderPage();
 
+      await user.click(screen.getByTestId('summary-edit-btn'));
       const saveBtn = screen.getByTestId('report-save-btn');
       await user.click(saveBtn);
 
@@ -501,16 +507,19 @@ describe('SnapshotViewerPage', () => {
       expect(screen.getByTestId('report-share-btn')).toBeInTheDocument();
     });
 
-    it('shows all action buttons when user has full permissions and is creator', () => {
+    it('shows all action buttons when user has full permissions and is creator', async () => {
+      const user = userEvent.setup();
       mockHasPermission.mockReturnValue(true);
       mockGetCurrentUserEmail.mockReturnValue('user@test.com');
       renderPage();
 
       expect(screen.getByTestId('report-download-btn')).toBeInTheDocument();
       expect(screen.getByTestId('report-share-btn')).toBeInTheDocument();
-      expect(screen.getByTestId('report-save-btn')).toBeInTheDocument();
       expect(screen.getByTestId('summary-edit-btn')).toBeInTheDocument();
       expect(screen.getByTestId('mock-comment-popover')).toBeInTheDocument();
+      // Save button only appears after entering edit mode
+      await user.click(screen.getByTestId('summary-edit-btn'));
+      expect(screen.getByTestId('report-save-btn')).toBeInTheDocument();
     });
   });
 

--- a/components/reports/report-share-menu.tsx
+++ b/components/reports/report-share-menu.tsx
@@ -53,11 +53,11 @@ export function ReportShareMenu({ snapshotId, reportTitle }: ReportShareMenuProp
         <DropdownMenuTrigger asChild>
           <Button
             data-testid="report-share-btn"
-            variant="ghost"
-            size="icon"
+            variant="outline"
+            size="sm"
             aria-label="Share report"
           >
-            <Share2 className="h-4 w-4" />
+            <Share2 className="w-4 h-4" />
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end">


### PR DESCRIPTION
Issue
When opening a report, the top header section looked visually different from the dashboard header — the background appeared slightly different, there was no subtle shadow under the header bar, the back button looked plain/unstyled, the date and metadata info was positioned awkwardly as a separate row instead of sitting neatly under the report title, and the Download/Share buttons had no visible border or depth compared to the dashboard buttons.

Fix

Made the report header background and shadow match the dashboard header
Moved the date, creator, and dashboard info to sit directly below the report title, just like how it appears in the dashboard
Made the Back button look consistent with the dashboard's Back button
Gave the Download and Share buttons the same bordered appearance as the dashboard action buttons

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Refined report header with background, shadow, and consolidated spacing; adjusted button outlines, sizes, and icon spacing (including share and download controls) for a consistent appearance.
  * Tweaked header layout and flex behavior to prevent title truncation and keep action buttons stable.

* **New Features / UX**
  * Moved metadata inline under the title and relocated Save out of the header—contextual Cancel and Save buttons now appear below the executive summary when editing; Cancel reverts edits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->