### PR TITLE
Fix/comment mention dropdown position and spacing

### DIFF
--- a/components/reports/comment-popover.tsx
+++ b/components/reports/comment-popover.tsx
@@ -115,7 +115,7 @@ const MentionDropdown = memo(function MentionDropdown({
           type="button"
           data-testid={`mention-user-${user.email}`}
           className={cn(
-            'w-full text-left px-3 py-2 text-sm flex items-center gap-2',
+            'w-full text-left px-4 py-3 text-sm flex items-center gap-3',
             idx === highlightedIndex ? 'bg-accent' : 'hover:bg-accent'
           )}
           onMouseDown={(e) => {
@@ -124,7 +124,7 @@ const MentionDropdown = memo(function MentionDropdown({
           }}
           onMouseEnter={() => onHighlightChange(idx)}
         >
-          <Avatar className="h-5 w-5 text-[10px] flex-shrink-0">
+          <Avatar className="h-7 w-7 text-xs flex-shrink-0">
             <AvatarFallback
               style={{ backgroundColor: getAvatarColor(user.email) }}
               className="text-white"
@@ -730,8 +730,8 @@ function CommentPopoverInner({
         )}
 
         {/* Add comment input */}
-        <div className={cn('p-3 flex-shrink-0', visibleComments.length > 0 && 'border-t')}>
-          <div className="relative">
+        <div className={cn('p-3 flex-shrink-0', visibleComments.length > 0 && 'border-t relative')}>
+          <div>
             <MentionDropdown
               filteredUsers={filteredMentionUsers}
               onSelect={handleMentionSelect}


### PR DESCRIPTION
Issue
The @mention user suggestion dropdown in the comment popover had two problems — the list items were too tightly packed with insufficient padding and small avatars making it hard to read, and the dropdown was appearing over the comment input area instead of outside the popover, obscuring the text being typed.

Fix

Increased padding and gap between mention list items for better readability
Fixed dropdown positioning so it appears outside and below the comment popover instead of overlapping the input
Standardized avatar size across mention list and comment list to 28px for visual consistency

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved the visual design of mention dropdown suggestions with enhanced spacing and larger avatar sizing for better visibility in the comment input area.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->