### PR TITLE
Revert "fix: switch to newly created org after creation in webapp_v2"

### DIFF
--- a/components/auth-guard.tsx
+++ b/components/auth-guard.tsx
@@ -39,21 +39,21 @@ export function AuthGuard({ children }: { children: React.ReactNode }) {
       setOrgUsers(orgUsersData);
       setIsCheckingAuth(false);
 
-      // Auto-select organization if none selected OR if stored org differs from current
-      const storedOrgSlug = localStorage.getItem('selectedOrg');
+      // Auto-select organization if none selected
+      if (!currentOrg) {
+        const storedOrgSlug = localStorage.getItem('selectedOrg');
 
-      if (!currentOrg || (storedOrgSlug && storedOrgSlug !== currentOrg?.slug)) {
         if (storedOrgSlug) {
           // Verify stored org exists
           const orgExists = orgUsersData.some((ou: any) => ou.org.slug === storedOrgSlug);
           if (orgExists) {
             setSelectedOrg(storedOrgSlug);
-          } else if (!currentOrg) {
-            // Stored org doesn't exist and no current org, select first one
+          } else {
+            // Stored org doesn't exist, select first one
             setSelectedOrg(orgUsersData[0].org.slug);
           }
-        } else if (!currentOrg) {
-          // No stored org and no current org, select first one
+        } else {
+          // No stored org, select first one
           setSelectedOrg(orgUsersData[0].org.slug);
         }
       }

--- a/components/auth-guard.tsx
+++ b/components/auth-guard.tsx
@@ -39,21 +39,21 @@ export function AuthGuard({ children }: { children: React.ReactNode }) {
       setOrgUsers(orgUsersData);
       setIsCheckingAuth(false);
 
-      // Auto-select organization if none selected
-      if (!currentOrg) {
-        const storedOrgSlug = localStorage.getItem('selectedOrg');
+      // Auto-select organization if none selected OR if stored org differs from current
+      const storedOrgSlug = localStorage.getItem('selectedOrg');
 
+      if (!currentOrg || (storedOrgSlug && storedOrgSlug !== currentOrg?.slug)) {
         if (storedOrgSlug) {
           // Verify stored org exists
           const orgExists = orgUsersData.some((ou: any) => ou.org.slug === storedOrgSlug);
           if (orgExists) {
             setSelectedOrg(storedOrgSlug);
-          } else {
-            // Stored org doesn't exist, select first one
+          } else if (!currentOrg) {
+            // Stored org doesn't exist and no current org, select first one
             setSelectedOrg(orgUsersData[0].org.slug);
           }
-        } else {
-          // No stored org, select first one
+        } else if (!currentOrg) {
+          // No stored org and no current org, select first one
           setSelectedOrg(orgUsersData[0].org.slug);
         }
       }

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -89,9 +89,6 @@ export function Header({
     // Update the selected org in store and localStorage
     setSelectedOrg(orgSlug);
 
-    // Clear all SWR caches so the new org gets fresh data
-    // await mutate(() => true, undefined, { revalidate: false });
-
     // Full reload ensures all API calls use the new org header cleanly
     window.location.reload();
   };

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -89,25 +89,11 @@ export function Header({
     // Update the selected org in store and localStorage
     setSelectedOrg(orgSlug);
 
-    try {
-      // Show loader for minimum 2 seconds to give substantial feel
-      const minDelay = new Promise((resolve) => setTimeout(resolve, 2000));
+    // Clear all SWR caches so the new org gets fresh data
+    // await mutate(() => true, undefined, { revalidate: false });
 
-      // Wait for minimum delay then refresh
-      await minDelay;
-
-      // Refresh the page to trigger data refetch with new org context
-      // This is essential for all API calls to use the new org header
-      router.refresh();
-
-      // Clear switching state after a slight delay to allow refresh to complete
-      setTimeout(() => {
-        setOrgSwitching(false);
-      }, 500);
-    } catch (error) {
-      // If anything goes wrong, clear the switching state
-      setOrgSwitching(false);
-    }
+    // Full reload ensures all API calls use the new org header cleanly
+    window.location.reload();
   };
 
   const handleLogout = async () => {

--- a/components/settings/organizations/CreateOrgDialog.tsx
+++ b/components/settings/organizations/CreateOrgDialog.tsx
@@ -20,7 +20,6 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { useOrganizationActions } from '@/hooks/api/useUserManagement';
-import { useRouter } from 'next/navigation';
 import { useAuthStore } from '@/stores/authStore';
 
 interface CreateOrgDialogProps {
@@ -47,7 +46,6 @@ const SUPERSET_OPTIONS = [
 
 export function CreateOrgDialog({ open, onOpenChange }: CreateOrgDialogProps) {
   const { createOrganization } = useOrganizationActions();
-  const router = useRouter();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [formData, setFormData] = useState({
     name: '',
@@ -59,7 +57,7 @@ export function CreateOrgDialog({ open, onOpenChange }: CreateOrgDialogProps) {
     end_date: '',
   });
   const [errors, setErrors] = useState<Record<string, string>>({});
-  const { refreshOrganizations } = useAuthStore();
+  const { refreshOrganizations, setSelectedOrg } = useAuthStore();
 
   const validateForm = () => {
     const newErrors: Record<string, string> = {};
@@ -122,14 +120,18 @@ export function CreateOrgDialog({ open, onOpenChange }: CreateOrgDialogProps) {
 
       const response = await createOrganization(payload);
 
-      if (response?.slug) {
-        localStorage.setItem('selectedOrg', response.slug);
-      }
-
       handleClose();
-      await refreshOrganizations();
-      router.refresh();
-    } catch (error) {
+      await refreshOrganizations()
+        .then(() => {
+          if (response?.slug) {
+            setSelectedOrg(response.slug);
+          }
+          window.location.reload();
+        })
+        .catch(() => {
+          // refreshOrganizations failed, org switch skipped
+        });
+    } catch {
       // Error is handled in the hook
     } finally {
       setIsSubmitting(false);

--- a/components/settings/organizations/CreateOrgDialog.tsx
+++ b/components/settings/organizations/CreateOrgDialog.tsx
@@ -20,6 +20,7 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { useOrganizationActions } from '@/hooks/api/useUserManagement';
+import { useRouter } from 'next/navigation';
 import { useAuthStore } from '@/stores/authStore';
 
 interface CreateOrgDialogProps {
@@ -46,6 +47,7 @@ const SUPERSET_OPTIONS = [
 
 export function CreateOrgDialog({ open, onOpenChange }: CreateOrgDialogProps) {
   const { createOrganization } = useOrganizationActions();
+  const router = useRouter();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [formData, setFormData] = useState({
     name: '',
@@ -118,11 +120,15 @@ export function CreateOrgDialog({ open, onOpenChange }: CreateOrgDialogProps) {
         end_date: formData.end_date || undefined,
       };
 
-      await createOrganization(payload);
+      const response = await createOrganization(payload);
 
-      await refreshOrganizations();
+      if (response?.slug) {
+        localStorage.setItem('selectedOrg', response.slug);
+      }
 
       handleClose();
+      await refreshOrganizations();
+      router.refresh();
     } catch (error) {
       // Error is handled in the hook
     } finally {


### PR DESCRIPTION
Issue
When a super admin created a new organization in webapp_v2, the app didn't automatically switch to that new organization after creation. The user had to manually switch to it or refresh the page themselves.

Fix 
auth-guard.tsx: Extended the org auto-select condition to also trigger when the stored org slug in localStorage differs from the current org (storedOrgSlug !== currentOrg?.slug). Added else if (!currentOrg) guards inside to prevent overriding a valid current org in edge cases.
CreateOrgDialog.tsx: On successful creation, save the new org slug to localStorage, call refreshOrganizations() to fetch the updated org list, and router.refresh() to re-render the UI with the new org active.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Org auto-selection now respects an already-selected organization and only applies a stored preference when none is selected.
* **Changes**
  * Newly created organizations are auto-selected when possible and the UI reloads to show updated org lists.
  * Switching organizations now triggers a full page reload to apply the change immediately; a transient loading state is shown during the switch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->