### PR TITLE
Migration/ingest page bugs fix

### DIFF
--- a/components/connections/connection-form.tsx
+++ b/components/connections/connection-form.tsx
@@ -213,7 +213,10 @@ export function ConnectionForm({ mode, connectionId, onClose, onSuccess }: Conne
 
   return (
     <Dialog open onOpenChange={(isOpen) => !isOpen && onClose()}>
-      <DialogContent className="sm:max-w-[70vw] max-h-[90vh] flex flex-col p-0 gap-0 overflow-hidden">
+      <DialogContent
+        className="sm:max-w-[70vw] max-h-[90vh] flex flex-col p-0 gap-0 overflow-hidden"
+        preventOutsideClose
+      >
         <DialogHeader className="flex-shrink-0 px-6 pt-6 pb-4 border-b">
           <DialogTitle>
             {isCreate ? 'New Connection' : isView ? 'View Connection' : 'Edit Connection'}

--- a/components/connections/schema-change-form.tsx
+++ b/components/connections/schema-change-form.tsx
@@ -107,7 +107,7 @@ export function SchemaChangeForm({ connectionId, onClose, onSuccess }: SchemaCha
 
   return (
     <Dialog open onOpenChange={(isOpen) => !isOpen && onClose()}>
-      <DialogContent className="sm:max-w-[80vw] max-h-[85vh] overflow-y-auto">
+      <DialogContent className="sm:max-w-[80vw] max-h-[85vh] overflow-y-auto" preventOutsideClose>
         <DialogHeader>
           <DialogTitle>Schema Changes</DialogTitle>
           <DialogDescription>

--- a/components/connections/stream-selection-dialog.tsx
+++ b/components/connections/stream-selection-dialog.tsx
@@ -72,7 +72,7 @@ export function StreamSelectionDialog({
 
   return (
     <Dialog open onOpenChange={(isOpen) => !isOpen && onClose()}>
-      <DialogContent className="sm:max-w-[70vw] max-h-[80vh] overflow-y-auto">
+      <DialogContent className="sm:max-w-[70vw] max-h-[80vh] overflow-y-auto" preventOutsideClose>
         <DialogHeader>
           <DialogTitle>Select Streams to Clear</DialogTitle>
           <DialogDescription>

--- a/components/connectors/fields/FieldLabel.tsx
+++ b/components/connectors/fields/FieldLabel.tsx
@@ -38,26 +38,26 @@ export function FieldLabel({ title, required, description, htmlFor }: FieldLabel
   );
 
   return (
-    <div className="flex items-center gap-1.5 mb-1.5">
+    <div className="mb-1.5">
       <label htmlFor={htmlFor} className="text-[15px] font-medium">
         {title}
         {required && <span className="text-destructive ml-0.5">*</span>}
+        {description && (
+          <TooltipProvider delayDuration={200}>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Info
+                  className="h-3.5 w-3.5 text-muted-foreground cursor-help inline-block align-middle ml-1"
+                  data-testid={`field-info-${htmlFor}`}
+                />
+              </TooltipTrigger>
+              <TooltipContent side="right" className="max-w-xs text-xs">
+                <p dangerouslySetInnerHTML={{ __html: sanitizedDescription }} />
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        )}
       </label>
-      {description && (
-        <TooltipProvider delayDuration={200}>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Info
-                className="h-3.5 w-3.5 text-muted-foreground cursor-help"
-                data-testid={`field-info-${htmlFor}`}
-              />
-            </TooltipTrigger>
-            <TooltipContent side="right" className="max-w-xs text-xs">
-              <p dangerouslySetInnerHTML={{ __html: sanitizedDescription }} />
-            </TooltipContent>
-          </Tooltip>
-        </TooltipProvider>
-      )}
     </div>
   );
 }

--- a/components/ingest/sources/SourceForm.tsx
+++ b/components/ingest/sources/SourceForm.tsx
@@ -265,7 +265,10 @@ export function SourceForm({ open, onClose, onSuccess, sourceId }: SourceFormPro
 
   return (
     <Dialog open={open} onOpenChange={(isOpen) => !isOpen && onClose()}>
-      <DialogContent className="sm:max-w-3xl max-h-[85vh] overflow-y-auto overscroll-none">
+      <DialogContent
+        className="sm:max-w-3xl max-h-[85vh] overflow-y-auto overscroll-none"
+        onInteractOutside={(e) => e.preventDefault()}
+      >
         <DialogHeader>
           <DialogTitle>{isEdit ? 'Edit Source' : 'Add Source'}</DialogTitle>
           <DialogDescription>

--- a/components/ingest/sources/SourceForm.tsx
+++ b/components/ingest/sources/SourceForm.tsx
@@ -267,7 +267,7 @@ export function SourceForm({ open, onClose, onSuccess, sourceId }: SourceFormPro
     <Dialog open={open} onOpenChange={(isOpen) => !isOpen && onClose()}>
       <DialogContent
         className="sm:max-w-3xl max-h-[85vh] overflow-y-auto overscroll-none"
-        onInteractOutside={(e) => e.preventDefault()}
+        preventOutsideClose
       >
         <DialogHeader>
           <DialogTitle>{isEdit ? 'Edit Source' : 'Add Source'}</DialogTitle>

--- a/components/ingest/sources/SourceList.tsx
+++ b/components/ingest/sources/SourceList.tsx
@@ -127,7 +127,7 @@ export function SourceList() {
                 placeholder="Search Sources"
                 value={searchQuery}
                 onChange={(e) => setSearchQuery(e.target.value)}
-                className="pl-9"
+                className="pl-9 bg-background"
                 data-testid="source-search-input"
               />
             </div>

--- a/components/ingest/warehouse/warehouse-form.tsx
+++ b/components/ingest/warehouse/warehouse-form.tsx
@@ -200,7 +200,7 @@ export function WarehouseForm({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
         className="sm:max-w-3xl max-h-[85vh] flex flex-col p-0 gap-0 overflow-hidden"
-        onInteractOutside={(e) => e.preventDefault()}
+        preventOutsideClose
       >
         {/* Pinned header */}
         <DialogHeader className="flex-shrink-0 px-6 pt-6 pb-4 border-b">

--- a/components/ingest/warehouse/warehouse-form.tsx
+++ b/components/ingest/warehouse/warehouse-form.tsx
@@ -198,7 +198,10 @@ export function WarehouseForm({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-3xl max-h-[85vh] flex flex-col p-0 gap-0 overflow-hidden">
+      <DialogContent
+        className="sm:max-w-3xl max-h-[85vh] flex flex-col p-0 gap-0 overflow-hidden"
+        onInteractOutside={(e) => e.preventDefault()}
+      >
         {/* Pinned header */}
         <DialogHeader className="flex-shrink-0 px-6 pt-6 pb-4 border-b">
           <DialogTitle>{isEditing ? 'Edit Warehouse' : 'Set Up Warehouse'}</DialogTitle>

--- a/components/main-layout.tsx
+++ b/components/main-layout.tsx
@@ -227,38 +227,46 @@ const getNavItems = (
   return filterMenuItemsForProduction(allNavItems);
 };
 
-// Flatten menu items for collapsed view based on expanded state
-const getFlattenedNavItems = (items: NavItemType[]): NavItemType[] => {
-  const flattened: NavItemType[] = [];
-
-  items.forEach((item) => {
-    // Skip hidden items
-    if (item.hide) return;
-
-    // Always include the parent item
-    flattened.push(item);
-
-    // Always include children in collapsed mode so sub-items are accessible
-    if (item.children) {
-      const visibleChildren = item.children.filter((child) => !child.hide);
-      flattened.push(...visibleChildren);
-    }
-  });
-
-  return flattened;
+// A parent menu item is "active" when the current path lives inside any of its visible children.
+const hasActiveChild = (item: NavItemType): boolean => {
+  if (!item.children) return false;
+  return item.children.some((child) => !child.hide && child.isActive);
 };
 
 // Collapsed navigation item component
-function CollapsedNavItem({ item }: { item: NavItemType }) {
+function CollapsedNavItem({
+  item,
+  onExpandSidebar,
+  isSubmenuExpanded = false,
+}: {
+  item: NavItemType;
+  onExpandSidebar?: () => void;
+  isSubmenuExpanded?: boolean;
+}) {
+  const visibleChildren = item.children?.filter((child) => !child.hide) || [];
+  const hasChildren = visibleChildren.length > 0;
+  // Only self-active highlights here. Parents (Data/Settings) never highlight in collapsed view —
+  // their children render directly below and carry the selection themselves.
+  const active = item.isActive;
+
   return (
     <TooltipProvider>
       <Tooltip>
         <TooltipTrigger asChild>
           <Link
             href={item.href}
+            onClick={() => {
+              // Parents (Data, Settings) expand the sidebar so the full submenu is visible.
+              if (hasChildren) {
+                onExpandSidebar?.();
+              }
+            }}
             className={cn(
               'flex items-center justify-center w-full p-3 rounded-lg hover:bg-[#0066FF]/3 hover:text-[#002B5C] transition-colors group',
-              item.isActive && 'bg-[#0066FF]/10 text-[#002B5C] font-bold'
+              // Border hints a parent has a submenu. Drop it once its submenu is open (children
+              // render below) — otherwise parent + highlighted child look like two selected items.
+              hasChildren && !isSubmenuExpanded && 'border border-border',
+              active && 'bg-[#0066FF]/10 text-[#002B5C] font-bold'
             )}
           >
             <item.icon className="h-6 w-6 flex-shrink-0" />
@@ -282,91 +290,10 @@ function ExpandedNavItem({
   isExpanded: boolean;
   onToggle: () => void;
 }) {
-  // Filter out hidden children
   const visibleChildren = item.children?.filter((child) => !child.hide) || [];
   const hasChildren = visibleChildren.length > 0;
 
-  // Auto-expand if any child is active
-  useEffect(() => {
-    if (!isExpanded && hasChildren && visibleChildren.some((child) => child.isActive)) {
-      onToggle(); // Expand if a child is active
-    }
-  }, []);
-
   if (hasChildren) {
-    // Special handling for Data tab - make it clickable and show submenu
-    if (item.title === 'Data') {
-      return (
-        <div className="space-y-1">
-          <div
-            className={cn(
-              'flex items-center rounded-lg transition-colors hover:bg-[#0066FF]/3 group',
-              item.isActive && 'bg-[#0066FF]/10 hover:bg-[#0066FF]/10'
-            )}
-          >
-            <Link
-              href={item.href}
-              onClick={() => {
-                // Expand the menu when navigating to show the selected item
-                if (!isExpanded) {
-                  onToggle();
-                }
-              }}
-              className={cn(
-                'flex items-center gap-3 p-3 transition-colors flex-1 rounded-l-lg group-hover:text-[#002B5C]',
-                item.isActive && 'text-[#002B5C] font-bold'
-              )}
-              title={item.title}
-            >
-              <item.icon className="h-6 w-6 flex-shrink-0" />
-              <span className={cn('font-medium', item.isActive && 'font-bold')}>{item.title}</span>
-            </Link>
-            <button
-              onClick={onToggle}
-              className={cn(
-                'p-2 transition-colors rounded-r-lg group-hover:text-[#002B5C]',
-                item.isActive && 'text-[#002B5C]'
-              )}
-              title="Toggle submenu"
-            >
-              <ChevronDown
-                className={cn(
-                  'h-4 w-4 transition-transform flex-shrink-0 text-muted-foreground group-hover:text-[#002B5C]',
-                  isExpanded && 'rotate-180',
-                  item.isActive && 'text-[#002B5C]'
-                )}
-              />
-            </button>
-          </div>
-
-          {isExpanded && (
-            <div className="ml-8 space-y-1">
-              {visibleChildren.map((child, index) => (
-                <Link
-                  key={index}
-                  href={child.href}
-                  className={cn(
-                    'flex items-center gap-3 p-3 rounded-lg hover:bg-[#0066FF]/3 hover:text-[#002B5C] transition-colors text-sm',
-                    child.isActive && 'bg-[#0066FF]/10 text-[#002B5C] font-bold'
-                  )}
-                  title={child.title}
-                >
-                  <child.icon
-                    className={cn(
-                      'flex-shrink-0',
-                      child.title === 'About' || child.title === 'Billing' ? 'h-5 w-5' : 'h-6 w-6'
-                    )}
-                  />
-                  <span>{child.title}</span>
-                </Link>
-              ))}
-            </div>
-          )}
-        </div>
-      );
-    }
-
-    // Default behavior for other items with children (Dashboards and Settings)
     return (
       <div className="space-y-1">
         <div
@@ -377,12 +304,6 @@ function ExpandedNavItem({
         >
           <Link
             href={item.href}
-            onClick={() => {
-              // Expand the menu when navigating to show the selected item
-              if (!isExpanded) {
-                onToggle();
-              }
-            }}
             className={cn(
               'flex items-center gap-3 p-3 transition-colors flex-1 rounded-l-lg group-hover:text-[#002B5C]',
               item.isActive && 'text-[#002B5C] font-bold'
@@ -393,18 +314,18 @@ function ExpandedNavItem({
             <span className={cn('font-medium', item.isActive && 'font-bold')}>{item.title}</span>
           </Link>
           <button
+            type="button"
             onClick={onToggle}
+            aria-label={`Toggle ${item.title} submenu`}
             className={cn(
               'p-2 transition-colors rounded-r-lg group-hover:text-[#002B5C]',
               item.isActive && 'text-[#002B5C]'
             )}
-            title="Toggle submenu"
           >
             <ChevronDown
               className={cn(
                 'h-4 w-4 transition-transform flex-shrink-0 text-muted-foreground group-hover:text-[#002B5C]',
-                isExpanded && 'rotate-180',
-                item.isActive && 'text-[#002B5C]'
+                isExpanded && 'rotate-180'
               )}
             />
           </button>
@@ -464,89 +385,10 @@ function MobileNavItem({
   isExpanded: boolean;
   onToggle: () => void;
 }) {
-  // Filter out hidden children
   const visibleChildren = item.children?.filter((child) => !child.hide) || [];
   const hasChildren = visibleChildren.length > 0;
 
-  // Auto-expand if any child is active
-  useEffect(() => {
-    if (!isExpanded && hasChildren && visibleChildren.some((child) => child.isActive)) {
-      onToggle(); // Expand if a child is active
-    }
-  }, []);
-
   if (hasChildren) {
-    // Special handling for Data tab in mobile view
-    if (item.title === 'Data') {
-      return (
-        <div className="space-y-1">
-          <div
-            className={cn(
-              'flex items-center rounded-lg transition-colors hover:bg-[#0066FF]/3 group',
-              item.isActive && 'bg-[#0066FF]/10 hover:bg-[#0066FF]/10'
-            )}
-          >
-            <Link
-              href={item.href}
-              onClick={() => {
-                // Expand the menu when navigating and close mobile menu
-                if (!isExpanded) {
-                  onToggle();
-                }
-                onClose();
-              }}
-              className={cn(
-                'flex items-center gap-3 p-3 transition-colors flex-1 rounded-l-lg group-hover:text-[#002B5C]',
-                item.isActive && 'text-[#002B5C] font-bold'
-              )}
-            >
-              <item.icon className="h-6 w-6" />
-              <span className={cn('font-medium', item.isActive && 'font-bold')}>{item.title}</span>
-            </Link>
-            <button
-              onClick={onToggle}
-              className={cn(
-                'p-2 transition-colors rounded-r-lg group-hover:text-[#002B5C]',
-                item.isActive && 'text-[#002B5C]'
-              )}
-            >
-              <ChevronDown
-                className={cn(
-                  'h-4 w-4 transition-transform text-muted-foreground group-hover:text-[#002B5C]',
-                  isExpanded && 'rotate-180',
-                  item.isActive && 'text-[#002B5C]'
-                )}
-              />
-            </button>
-          </div>
-          {isExpanded && (
-            <div className="ml-8 space-y-1">
-              {visibleChildren.map((child, index) => (
-                <Link
-                  key={index}
-                  href={child.href}
-                  onClick={onClose}
-                  className={cn(
-                    'flex items-center gap-3 p-3 rounded-lg hover:bg-[#0066FF]/3 hover:text-[#002B5C] transition-colors',
-                    child.isActive && 'bg-[#0066FF]/10 text-[#002B5C] font-bold'
-                  )}
-                >
-                  <child.icon
-                    className={cn(
-                      'flex-shrink-0',
-                      child.title === 'About' || child.title === 'Billing' ? 'h-5 w-5' : 'h-6 w-6'
-                    )}
-                  />
-                  <span className="text-sm">{child.title}</span>
-                </Link>
-              ))}
-            </div>
-          )}
-        </div>
-      );
-    }
-
-    // Default behavior for other items with children (Dashboards and Settings)
     return (
       <div className="space-y-1">
         <div
@@ -557,13 +399,7 @@ function MobileNavItem({
         >
           <Link
             href={item.href}
-            onClick={() => {
-              // Expand the menu when navigating and close mobile menu
-              if (!isExpanded) {
-                onToggle();
-              }
-              onClose();
-            }}
+            onClick={onClose}
             className={cn(
               'flex items-center gap-3 p-3 transition-colors flex-1 rounded-l-lg group-hover:text-[#002B5C]',
               item.isActive && 'text-[#002B5C] font-bold'
@@ -573,7 +409,9 @@ function MobileNavItem({
             <span className={cn('font-medium', item.isActive && 'font-bold')}>{item.title}</span>
           </Link>
           <button
+            type="button"
             onClick={onToggle}
+            aria-label={`Toggle ${item.title} submenu`}
             className={cn(
               'p-2 transition-colors rounded-r-lg group-hover:text-[#002B5C]',
               item.isActive && 'text-[#002B5C]'
@@ -582,8 +420,7 @@ function MobileNavItem({
             <ChevronDown
               className={cn(
                 'h-4 w-4 transition-transform text-muted-foreground group-hover:text-[#002B5C]',
-                isExpanded && 'rotate-180',
-                item.isActive && 'text-[#002B5C]'
+                isExpanded && 'rotate-180'
               )}
             />
           </button>
@@ -635,6 +472,9 @@ export function MainLayout({ children }: { children: React.ReactNode }) {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
   const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(false);
   const [hasUserToggledSidebar, setHasUserToggledSidebar] = useState(false);
+  // Explicit open/closed state per parent menu. `undefined` means "follow the path" (fallback
+  // to hasActiveChild). Once set (auto on subtree entry, or manually via the chevron), the
+  // state persists — navigating out of a subtree does NOT auto-close the parent.
   const [expandedMenus, setExpandedMenus] = useState<Record<string, boolean>>({});
   const responsive = useResponsiveLayout();
   const { currentOrg } = useAuthStore();
@@ -642,11 +482,28 @@ export function MainLayout({ children }: { children: React.ReactNode }) {
   const { transformType } = useTransformType();
   const hasSupersetSetup = Boolean(currentOrg?.viz_url);
   const navItems = getNavItems(pathname, hasSupersetSetup, isFeatureFlagEnabled, transformType);
-  const flattenedNavItems = getFlattenedNavItems(navItems);
 
-  // Toggle menu expansion state
-  const toggleMenuExpansion = (title: string) => {
-    setExpandedMenus((prev) => ({ ...prev, [title]: !prev[title] }));
+  // Auto-open a parent's submenu when the current path enters its subtree. Never auto-closes.
+  useEffect(() => {
+    setExpandedMenus((prev) => {
+      let next = prev;
+      for (const item of navItems) {
+        if (item.children && hasActiveChild(item) && !next[item.title]) {
+          next = { ...next, [item.title]: true };
+        }
+      }
+      return next;
+    });
+    // navItems is recomputed each render from the same inputs; depending on pathname is sufficient.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pathname]);
+
+  const getMenuExpanded = (item: NavItemType): boolean =>
+    expandedMenus[item.title] ?? hasActiveChild(item);
+
+  const toggleMenuExpansion = (item: NavItemType) => {
+    const current = getMenuExpanded(item);
+    setExpandedMenus((prev) => ({ ...prev, [item.title]: !current }));
   };
 
   // Auto-collapse sidebar on specific dashboard/chart pages
@@ -732,21 +589,44 @@ export function MainLayout({ children }: { children: React.ReactNode }) {
             {/* Sidebar Navigation */}
             <div id="main-layout-sidebar-nav" className="flex-1 overflow-y-auto p-4 space-y-2">
               {isSidebarCollapsed
-                ? // Collapsed: Show all items (including nested) as individual icons with tooltips
-                  flattenedNavItems
+                ? // Collapsed: top-level icons; if a parent's submenu is open (path-derived or
+                  // manually toggled), render its children as icons directly beneath it.
+                  navItems
                     .filter((item) => !item.hide)
-                    .map((item, index) => (
-                      <CollapsedNavItem key={`${item.href}-${index}`} item={item} />
-                    ))
-                : // Expanded: Show hierarchical structure
+                    .map((item, index) => {
+                      const visibleChildren = item.children?.filter((c) => !c.hide) || [];
+                      const expanded = getMenuExpanded(item);
+                      const showChildren = expanded && visibleChildren.length > 0;
+                      return (
+                        <div key={`${item.href}-${index}`} className="space-y-1">
+                          <CollapsedNavItem
+                            item={item}
+                            isSubmenuExpanded={expanded}
+                            onExpandSidebar={() => {
+                              setIsSidebarCollapsed(false);
+                              setHasUserToggledSidebar(true);
+                            }}
+                          />
+                          {showChildren && (
+                            <div className="space-y-1">
+                              {visibleChildren.map((child, cIdx) => (
+                                <CollapsedNavItem key={`${child.href}-${cIdx}`} item={child} />
+                              ))}
+                            </div>
+                          )}
+                        </div>
+                      );
+                    })
+                : // Expanded: hierarchical; submenu auto-opens on subtree entry, stays until the
+                  // user closes it via the chevron.
                   navItems
                     .filter((item) => !item.hide)
                     .map((item, index) => (
                       <ExpandedNavItem
                         key={index}
                         item={item}
-                        isExpanded={expandedMenus[item.title] || false}
-                        onToggle={() => toggleMenuExpansion(item.title)}
+                        isExpanded={getMenuExpanded(item)}
+                        onToggle={() => toggleMenuExpansion(item)}
                       />
                     ))}
             </div>
@@ -780,8 +660,8 @@ export function MainLayout({ children }: { children: React.ReactNode }) {
                       key={index}
                       item={item}
                       onClose={() => setIsMobileMenuOpen(false)}
-                      isExpanded={expandedMenus[item.title] || false}
-                      onToggle={() => toggleMenuExpansion(item.title)}
+                      isExpanded={getMenuExpanded(item)}
+                      onToggle={() => toggleMenuExpansion(item)}
                     />
                   ))}
               </div>

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -42,9 +42,12 @@ function DialogContent({
   className,
   children,
   showCloseButton = true,
+  preventOutsideClose = false,
+  onInteractOutside,
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Content> & {
   showCloseButton?: boolean;
+  preventOutsideClose?: boolean;
 }) {
   return (
     <DialogPortal data-slot="dialog-portal">
@@ -55,6 +58,12 @@ function DialogContent({
           'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg',
           className
         )}
+        onInteractOutside={(e) => {
+          if (preventOutsideClose) {
+            e.preventDefault();
+          }
+          onInteractOutside?.(e);
+        }}
         {...props}
       >
         {children}


### PR DESCRIPTION
Issue
Several UI bugs on the ingest page:

Source and warehouse edit dialogs were closing when clicking outside, causing users to lose their form data accidentally
Tooltip info icon was misaligned in field labels
Search input on the sources list had no background color, making it blend with the page
Fix
SourceForm.tsx & warehouse-form.tsx: Added onInteractOutside={(e) => e.preventDefault()} to prevent dialogs from closing on outside click
FieldLabel.tsx: Fixed tooltip info icon positioning
SourceList.tsx: Added bg-background to source search input for proper white background