### PR TITLE
fix: apply default font size when switching heading levels in text wi…

### DIFF
--- a/components/dashboard/text-element-unified.tsx
+++ b/components/dashboard/text-element-unified.tsx
@@ -324,19 +324,26 @@ export function UnifiedTextElement({
       const scrollTop = textarea?.scrollTop || 0;
       const parentScroll = containerRef.current?.scrollTop || 0;
 
+      // Default font sizes matching standard HTML heading hierarchy
+      const headingFontSizes: Record<number, number> = { 1: 32, 2: 24, 3: 20 };
+      // Default paragraph size matches base text size used across the app
+      const paragraphFontSize = 14;
+
       if (newType === 'paragraph') {
         updateWithContentConstraints({
           ...config,
-          content: tempContent, // Auto-save current content
+          content: tempContent,
           type: 'paragraph',
+          fontSize: paragraphFontSize,
         });
       } else {
         const headingLevel = newType as 1 | 2 | 3;
         updateWithContentConstraints({
           ...config,
-          content: tempContent, // Auto-save current content
+          content: tempContent,
           type: 'heading',
           headingLevel,
+          fontSize: headingFontSizes[headingLevel],
         });
       }
 


### PR DESCRIPTION
Issue
In the dashboard text widget, clicking H1, H2, or H3 heading buttons had no visible effect on font size — all heading levels appeared the same size as the previously set font size.

Fix
Updated handleTypeChange in text-element-unified.tsx to apply a default font size when switching text type:

H1 → 32px
H2 → 24px
H3 → 20px
Paragraph → 14px

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Text elements now apply consistent font sizing when switching between text types. Paragraphs automatically receive a standard font size, while headings adjust their size based on heading level (H1, H2, H3), ensuring proper visual hierarchy throughout the document.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->