### PR TITLE
prevent month selector layout shift in date picker

### DIFF
--- a/components/ui/date-picker.tsx
+++ b/components/ui/date-picker.tsx
@@ -142,6 +142,7 @@ export function DatePicker({
             onSelect={(date) => onSelect(date)}
             disabled={calendarDisabled}
             captionLayout="dropdown"
+            fixedWeeks
           />
 
           {showFooter && (


### PR DESCRIPTION
## Summary

Added `fixedWeeks` prop to the `Calendar` component to fix the
prev/next arrows shifting position when switching between months
with different name lengths (e.g. "May" vs "September").

## Testing

- [x] Switch between short and long month names — arrows stay fixed
- [x] Date selection still works correctly


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced date picker calendar rendering to provide more consistent week display formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->