### PR TITLE
Fix report edge case when no time filters are available

### DIFF
--- a/components/reports/create-snapshot-dialog.tsx
+++ b/components/reports/create-snapshot-dialog.tsx
@@ -133,20 +133,26 @@ export function CreateSnapshotDialog({
     });
   };
 
-  const onSubmit = async (data: SnapshotFormData) => {
-    // Parse selected date column
-    const [schema_name, table_name, column_name] = data.selectedDateColumn.split('.');
-    const dateColumn: DateColumn = { schema_name, table_name, column_name };
+  const hasDatetimeColumns = discoveredColumns.length > 0;
 
+  const onSubmit = async (data: SnapshotFormData) => {
     setIsSubmitting(true);
     try {
-      await createSnapshot({
+      const payload: Parameters<typeof createSnapshot>[0] = {
         title: data.reportName.trim(),
         dashboard_id: effectiveDashboardId!,
-        date_column: dateColumn,
-        period_start: data.periodStart ? format(data.periodStart, 'yyyy-MM-dd') : undefined,
-        period_end: format(data.periodEnd!, 'yyyy-MM-dd'),
-      });
+      };
+
+      if (hasDatetimeColumns && data.selectedDateColumn) {
+        const [schema_name, table_name, column_name] = data.selectedDateColumn.split('.');
+        payload.date_column = { schema_name, table_name, column_name } as DateColumn;
+        payload.period_start = data.periodStart
+          ? format(data.periodStart, 'yyyy-MM-dd')
+          : undefined;
+        payload.period_end = data.periodEnd ? format(data.periodEnd, 'yyyy-MM-dd') : undefined;
+      }
+
+      await createSnapshot(payload);
       toastSuccess.created('Report');
       setOpen(false);
       resetForm();
@@ -230,103 +236,105 @@ export function CreateSnapshotDialog({
             )}
           </div>
 
-          {/* Filter by */}
-          <div className="space-y-2">
-            <Label className="font-semibold">
-              Filter by <span className="text-red-600 ml-1">*</span>
-            </Label>
-            {effectiveDashboardId &&
+          {/* No datetime columns message */}
+          {effectiveDashboardId &&
             !columnsLoading &&
             discoveredColumns.length === 0 &&
-            dashboardData ? (
+            dashboardData && (
               <p className="text-sm text-muted-foreground">
-                No datetime columns found in this dashboard&apos;s data sources.
+                No datetime columns found in this dashboard&apos;s data sources. The report will be
+                created without date filtering.
               </p>
-            ) : (
-              <>
-                <Controller
-                  name="selectedDateColumn"
-                  control={control}
-                  rules={{ required: 'Please select a date-time column' }}
-                  render={({ field }) => (
-                    <Select
-                      value={field.value}
-                      onValueChange={field.onChange}
-                      disabled={
-                        !effectiveDashboardId || columnsLoading || discoveredColumns.length === 0
-                      }
-                    >
-                      <SelectTrigger data-testid="snapshot-date-column">
-                        <SelectValue
-                          placeholder={
-                            columnsLoading
-                              ? 'Discovering date columns...'
-                              : 'Pick the date-time column to filter by'
-                          }
-                        />
-                      </SelectTrigger>
-                      <SelectContent>
-                        {discoveredColumns.map((col) => {
-                          const value = `${col.schema_name}.${col.table_name}.${col.column_name}`;
-                          return (
-                            <SelectItem key={value} value={value}>
-                              {col.table_name}.{col.column_name}
-                            </SelectItem>
-                          );
-                        })}
-                      </SelectContent>
-                    </Select>
-                  )}
-                />
-                {errors.selectedDateColumn && (
-                  <p className="text-sm text-red-500">{errors.selectedDateColumn.message}</p>
-                )}
-              </>
             )}
-          </div>
 
-          {/* Duration */}
-          <div className="space-y-2">
-            <Label className="font-semibold">
-              Duration <span className="text-red-600 ml-1">*</span>
-            </Label>
-            <div className="grid grid-cols-2 gap-4">
-              <div className="space-y-1">
-                <span className="text-sm text-muted-foreground">Start date</span>
-                <Controller
-                  name="periodStart"
-                  control={control}
-                  render={({ field }) => (
-                    <ConfirmDatePicker
-                      value={field.value}
-                      onChange={field.onChange}
-                      maxDate={startMaxDate}
-                    />
-                  )}
-                />
-              </div>
-              <div className="space-y-1">
-                <span className="text-sm text-muted-foreground">
-                  End date <span className="text-red-600">*</span>
-                </span>
-                <Controller
-                  name="periodEnd"
-                  control={control}
-                  rules={{ required: 'Please select an end date' }}
-                  render={({ field }) => (
-                    <ConfirmDatePicker
-                      value={field.value}
-                      onChange={field.onChange}
-                      maxDate={today}
-                    />
-                  )}
-                />
-                {errors.periodEnd && (
-                  <p className="text-sm text-red-500">{errors.periodEnd.message}</p>
+          {/* Filter by — only shown when datetime columns exist */}
+          {hasDatetimeColumns && (
+            <div className="space-y-2">
+              <Label className="font-semibold">
+                Filter by <span className="text-red-600 ml-1">*</span>
+              </Label>
+              <Controller
+                name="selectedDateColumn"
+                control={control}
+                rules={hasDatetimeColumns ? { required: 'Please select a date-time column' } : {}}
+                render={({ field }) => (
+                  <Select
+                    value={field.value}
+                    onValueChange={field.onChange}
+                    disabled={!effectiveDashboardId || columnsLoading}
+                  >
+                    <SelectTrigger data-testid="snapshot-date-column">
+                      <SelectValue
+                        placeholder={
+                          columnsLoading
+                            ? 'Discovering date columns...'
+                            : 'Pick the date-time column to filter by'
+                        }
+                      />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {discoveredColumns.map((col) => {
+                        const value = `${col.schema_name}.${col.table_name}.${col.column_name}`;
+                        return (
+                          <SelectItem key={value} value={value}>
+                            {col.table_name}.{col.column_name}
+                          </SelectItem>
+                        );
+                      })}
+                    </SelectContent>
+                  </Select>
                 )}
+              />
+              {errors.selectedDateColumn && (
+                <p className="text-sm text-red-500">{errors.selectedDateColumn.message}</p>
+              )}
+            </div>
+          )}
+
+          {/* Duration — only shown when datetime columns exist */}
+          {hasDatetimeColumns && (
+            <div className="space-y-2">
+              <Label className="font-semibold">
+                Duration <span className="text-red-600 ml-1">*</span>
+              </Label>
+              <div className="grid grid-cols-2 gap-4">
+                <div className="space-y-1">
+                  <span className="text-sm text-muted-foreground">Start date</span>
+                  <Controller
+                    name="periodStart"
+                    control={control}
+                    render={({ field }) => (
+                      <ConfirmDatePicker
+                        value={field.value}
+                        onChange={field.onChange}
+                        maxDate={startMaxDate}
+                      />
+                    )}
+                  />
+                </div>
+                <div className="space-y-1">
+                  <span className="text-sm text-muted-foreground">
+                    End date <span className="text-red-600">*</span>
+                  </span>
+                  <Controller
+                    name="periodEnd"
+                    control={control}
+                    rules={hasDatetimeColumns ? { required: 'Please select an end date' } : {}}
+                    render={({ field }) => (
+                      <ConfirmDatePicker
+                        value={field.value}
+                        onChange={field.onChange}
+                        maxDate={today}
+                      />
+                    )}
+                  />
+                  {errors.periodEnd && (
+                    <p className="text-sm text-red-500">{errors.periodEnd.message}</p>
+                  )}
+                </div>
               </div>
             </div>
-          </div>
+          )}
         </div>
 
         {/* Buttons - left aligned */}

--- a/components/reports/create-snapshot-dialog.tsx
+++ b/components/reports/create-snapshot-dialog.tsx
@@ -74,6 +74,7 @@ export function CreateSnapshotDialog({
     watch,
     setValue,
     reset,
+    clearErrors,
     formState: { errors },
   } = useForm<SnapshotFormData>({
     defaultValues: {
@@ -134,6 +135,13 @@ export function CreateSnapshotDialog({
   };
 
   const hasDatetimeColumns = discoveredColumns.length > 0;
+
+  // Clear date field validation errors when no datetime columns are available
+  useEffect(() => {
+    if (!hasDatetimeColumns) {
+      clearErrors(['selectedDateColumn', 'periodEnd']);
+    }
+  }, [hasDatetimeColumns, clearErrors]);
 
   const onSubmit = async (data: SnapshotFormData) => {
     setIsSubmitting(true);
@@ -236,23 +244,17 @@ export function CreateSnapshotDialog({
             )}
           </div>
 
-          {/* No datetime columns message */}
-          {effectiveDashboardId &&
-            !columnsLoading &&
-            discoveredColumns.length === 0 &&
-            dashboardData && (
-              <p className="text-sm text-muted-foreground">
-                No datetime columns found in this dashboard&apos;s data sources. The report will be
-                created without date filtering.
-              </p>
-            )}
-
-          {/* Filter by — only shown when datetime columns exist */}
-          {hasDatetimeColumns && (
+          {/* Filter by */}
+          <div className={!hasDatetimeColumns ? 'opacity-50' : ''}>
             <div className="space-y-2">
               <Label className="font-semibold">
-                Filter by <span className="text-red-600 ml-1">*</span>
+                Filter by {hasDatetimeColumns && <span className="text-red-600 ml-1">*</span>}
               </Label>
+              {!hasDatetimeColumns && effectiveDashboardId && !columnsLoading && dashboardData && (
+                <p className="text-sm text-muted-foreground">
+                  No datetime columns found — date filtering will be skipped.
+                </p>
+              )}
               <Controller
                 name="selectedDateColumn"
                 control={control}
@@ -261,14 +263,16 @@ export function CreateSnapshotDialog({
                   <Select
                     value={field.value}
                     onValueChange={field.onChange}
-                    disabled={!effectiveDashboardId || columnsLoading}
+                    disabled={!hasDatetimeColumns || !effectiveDashboardId || columnsLoading}
                   >
                     <SelectTrigger data-testid="snapshot-date-column">
                       <SelectValue
                         placeholder={
                           columnsLoading
                             ? 'Discovering date columns...'
-                            : 'Pick the date-time column to filter by'
+                            : !hasDatetimeColumns
+                              ? 'No date columns available'
+                              : 'Pick the date-time column to filter by'
                         }
                       />
                     </SelectTrigger>
@@ -289,13 +293,13 @@ export function CreateSnapshotDialog({
                 <p className="text-sm text-red-500">{errors.selectedDateColumn.message}</p>
               )}
             </div>
-          )}
+          </div>
 
-          {/* Duration — only shown when datetime columns exist */}
-          {hasDatetimeColumns && (
+          {/* Duration */}
+          <div className={!hasDatetimeColumns ? 'opacity-50 pointer-events-none' : ''}>
             <div className="space-y-2">
               <Label className="font-semibold">
-                Duration <span className="text-red-600 ml-1">*</span>
+                Duration {hasDatetimeColumns && <span className="text-red-600 ml-1">*</span>}
               </Label>
               <div className="grid grid-cols-2 gap-4">
                 <div className="space-y-1">
@@ -314,7 +318,7 @@ export function CreateSnapshotDialog({
                 </div>
                 <div className="space-y-1">
                   <span className="text-sm text-muted-foreground">
-                    End date <span className="text-red-600">*</span>
+                    End date {hasDatetimeColumns && <span className="text-red-600">*</span>}
                   </span>
                   <Controller
                     name="periodEnd"
@@ -334,7 +338,7 @@ export function CreateSnapshotDialog({
                 </div>
               </div>
             </div>
-          )}
+          </div>
         </div>
 
         {/* Buttons - left aligned */}

--- a/types/reports.ts
+++ b/types/reports.ts
@@ -62,9 +62,9 @@ export interface DiscoveredDatetimeColumn {
 export interface CreateSnapshotPayload {
   title: string;
   dashboard_id: number;
-  date_column: DateColumn;
+  date_column?: DateColumn;
   period_start?: string;
-  period_end: string;
+  period_end?: string;
   description?: string;
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Date filtering in snapshot creation is now optional. The dialog gracefully handles missing datetime columns by skipping date-related fields instead of requiring them.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->