### PR TITLE
fix: show stacked bar total in dashboard labels and apply number form…

### DIFF
--- a/components/dashboard/chart-element-v2.tsx
+++ b/components/dashboard/chart-element-v2.tsx
@@ -51,6 +51,7 @@ import {
   applyLineBarChartFormatting,
   applyLineBarDateFormatting,
 } from '@/lib/chart-formatting-utils';
+import { applyStackedBarLabels } from '@/lib/stacked-bar-utils';
 import { ChartTypes, type ChartDataPayload } from '@/types/charts';
 import * as echarts from 'echarts/core';
 import { BarChart, LineChart, PieChart, GaugeChart, ScatterChart, MapChart } from 'echarts/charts';
@@ -1020,6 +1021,12 @@ export function ChartElementV2({
       if (isLineChart || isBarChart) {
         applyLineBarChartFormatting(modifiedConfig, customizations);
         applyLineBarDateFormatting(modifiedConfig, customizations);
+      }
+
+      // Apply stacked bar data labels (shows total at top of each stacked bar)
+      if (isBarChart) {
+        const stackedConfig = applyStackedBarLabels(modifiedConfig, customizations);
+        Object.assign(modifiedConfig, stackedConfig);
       }
 
       // Set chart option with animation disabled for better performance

--- a/components/dashboard/chart-element-view.tsx
+++ b/components/dashboard/chart-element-view.tsx
@@ -51,6 +51,7 @@ import {
   applyLineBarChartFormatting,
   applyLineBarDateFormatting,
 } from '@/lib/chart-formatting-utils';
+import { applyStackedBarLabels } from '@/lib/stacked-bar-utils';
 import { ChartTypes, type ChartDataPayload } from '@/types/charts';
 import type { FrozenChartConfig } from '@/types/reports';
 import { useFullscreen } from '@/hooks/useFullscreen';
@@ -1412,6 +1413,12 @@ export function ChartElementView({
     if (isLineChart || isBarChart) {
       applyLineBarChartFormatting(styledConfig, customizations);
       applyLineBarDateFormatting(styledConfig, customizations);
+    }
+
+    // Apply stacked bar data labels (shows total at top of each stacked bar)
+    if (isBarChart) {
+      const stackedConfig = applyStackedBarLabels(styledConfig, customizations);
+      Object.assign(styledConfig, stackedConfig);
     }
 
     // Check DOM element dimensions before setting options

--- a/lib/stacked-bar-utils.ts
+++ b/lib/stacked-bar-utils.ts
@@ -2,6 +2,8 @@
  * Utility for handling stacked bar chart data labels
  */
 
+import { formatNumber, NumberFormats, type NumberFormat } from './formatters';
+
 /**
  * Extract numeric value from various ECharts data formats
  */
@@ -13,9 +15,18 @@ function extractValue(value: any): number {
 }
 
 /**
- * Create a formatter that shows total of all series at the given data index
+ * Create a formatter that shows total of all series at the given data index,
+ * applying the chart's number formatting customizations.
  */
-export function createStackedTotalFormatter(seriesArray: any[]) {
+export function createStackedTotalFormatter(
+  seriesArray: any[],
+  customizations: Record<string, any> = {}
+) {
+  const numFormat = (customizations.yAxisNumberFormat ||
+    customizations.numberFormat ||
+    NumberFormats.DEFAULT) as NumberFormat;
+  const decimalPlaces = customizations.yAxisDecimalPlaces ?? customizations.decimalPlaces;
+
   return function (params: any): string {
     const dataIndex = params.dataIndex;
 
@@ -27,7 +38,11 @@ export function createStackedTotalFormatter(seriesArray: any[]) {
     }
 
     if (total === 0) return '';
-    return total.toLocaleString();
+
+    if (numFormat === NumberFormats.DEFAULT && decimalPlaces === undefined) {
+      return total.toLocaleString();
+    }
+    return formatNumber(total, { format: numFormat, decimalPlaces });
   };
 }
 
@@ -66,7 +81,7 @@ export function applyStackedBarLabels(
             ...series.label,
             show: true,
             position: 'top',
-            formatter: createStackedTotalFormatter(seriesArray),
+            formatter: createStackedTotalFormatter(seriesArray, customizations),
           },
         };
       } else {


### PR DESCRIPTION
Summary
Stacked bar chart data labels (total shown at top of each bar) were not respecting the chart's number format and decimal places settings — they always displayed raw numbers via toLocaleString()
Fixed by passing customizations to createStackedTotalFormatter so labels use the same formatNumber logic as tooltips
Applied the fix in both chart-element-v2.tsx (builder/edit mode) and chart-element-view.tsx (dashboard view mode)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Stacked bar charts now display aggregate total values at the top of each bar for improved readability
  * Total label values respect custom number formatting settings, including decimal places and number format configurations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->