### PR TITLE
handle continue on sync failure

### DIFF
--- a/components/pipeline/orchestrate/__tests__/pipeline-mock-data.ts
+++ b/components/pipeline/orchestrate/__tests__/pipeline-mock-data.ts
@@ -89,6 +89,7 @@ export const mockPipelineDetail: PipelineDetailResponse = {
   name: 'Pipeline Detail',
   cron: '0 9 * * *',
   isScheduleActive: true,
+  continueOnSyncFailure: false,
   connections: [{ id: 'conn-1', name: 'Postgres Source', seq: 1 }],
   transformTasks: [
     { uuid: 'task-2', seq: 1 },

--- a/components/pipeline/orchestrate/__tests__/pipeline-mock-data.ts
+++ b/components/pipeline/orchestrate/__tests__/pipeline-mock-data.ts
@@ -4,7 +4,8 @@
  * Extracted from MSW handlers for use with Jest mocks.
  */
 
-import type { Pipeline, TransformTask, Connection, PipelineDetailResponse } from '@/types/pipeline';
+import type { Pipeline, TransformTask, PipelineDetailResponse } from '@/types/pipeline';
+import type { Connection } from '@/types/connections';
 import { LockStatus } from '@/constants/pipeline';
 
 // ============ Mock Data Factories ============
@@ -40,13 +41,13 @@ export const createMockConnection = (overrides: Partial<Connection> = {}): Conne
   connectionId: 'conn-123',
   deploymentId: 'dep-123',
   catalogId: 'cat-123',
-  destination: { destinationId: 'dest-1', destinationName: 'Warehouse' },
-  source: { sourceId: 'src-1', sourceName: 'Database' },
+  destination: { destinationId: 'dest-1', name: 'Warehouse', destinationName: 'Warehouse' },
+  source: { sourceId: 'src-1', name: 'Database', sourceName: 'Database' },
   lock: null,
   lastRun: null,
   normalize: false,
   status: 'active',
-  syncCatalog: {},
+  syncCatalog: { streams: [] },
   resetConnDeploymentId: null,
   clearConnDeploymentId: null,
   queuedFlowRunWaitTime: null,

--- a/components/pipeline/orchestrate/__tests__/pipeline.test.tsx
+++ b/components/pipeline/orchestrate/__tests__/pipeline.test.tsx
@@ -12,7 +12,8 @@ import { PipelineForm } from '../pipeline-form';
 import { TaskSequence } from '../task-sequence';
 import * as usePipelinesHook from '@/hooks/api/usePipelines';
 import * as usePermissionsHook from '@/hooks/api/usePermissions';
-import type { Pipeline, TransformTask, Connection, PipelineDetailResponse } from '@/types/pipeline';
+import type { Pipeline, TransformTask, PipelineDetailResponse } from '@/types/pipeline';
+import type { Connection } from '@/types/connections';
 import { LockStatus } from '@/constants/pipeline';
 
 // ============ Mocks ============
@@ -112,13 +113,13 @@ const createConnection = (overrides: Partial<Connection> = {}): Connection => ({
   connectionId: 'conn-1',
   deploymentId: 'dep-1',
   catalogId: 'cat-1',
-  destination: { destinationId: 'dest-1', destinationName: 'Dest 1' },
-  source: { sourceId: 'src-1', sourceName: 'Source 1' },
+  destination: { destinationId: 'dest-1', name: 'Dest 1', destinationName: 'Dest 1' },
+  source: { sourceId: 'src-1', name: 'Source 1', sourceName: 'Source 1' },
   lock: null,
   lastRun: null,
   normalize: false,
   status: 'active',
-  syncCatalog: {},
+  syncCatalog: { streams: [] },
   resetConnDeploymentId: null,
   clearConnDeploymentId: null,
   queuedFlowRunWaitTime: null,

--- a/components/pipeline/orchestrate/__tests__/pipeline.test.tsx
+++ b/components/pipeline/orchestrate/__tests__/pipeline.test.tsx
@@ -822,7 +822,7 @@ describe('PipelineForm - Edit Mode Edge Cases', () => {
     // Checkbox is hidden behind Optional toggle
     expect(screen.queryByTestId('continue-on-sync-failure-checkbox')).not.toBeInTheDocument();
 
-    await user.click(screen.getByTestId('optional-settings-toggle'));
+    await user.click(screen.getByTestId('advanced-settings-toggle'));
 
     const checkbox = screen.getByTestId('continue-on-sync-failure-checkbox');
     expect(checkbox).toBeInTheDocument();
@@ -861,7 +861,7 @@ describe('PipelineForm - Edit Mode Edge Cases', () => {
 
     render(<PipelineForm deploymentId="test-dep" />);
 
-    await user.click(screen.getByTestId('optional-settings-toggle'));
+    await user.click(screen.getByTestId('advanced-settings-toggle'));
 
     await waitFor(() => {
       const checkbox = screen.getByTestId('continue-on-sync-failure-checkbox');
@@ -901,7 +901,7 @@ describe('PipelineForm - Edit Mode Edge Cases', () => {
 
     render(<PipelineForm deploymentId="old-dep" />);
 
-    await user.click(screen.getByTestId('optional-settings-toggle'));
+    await user.click(screen.getByTestId('advanced-settings-toggle'));
 
     await waitFor(() => {
       const checkbox = screen.getByTestId('continue-on-sync-failure-checkbox');

--- a/components/pipeline/orchestrate/__tests__/pipeline.test.tsx
+++ b/components/pipeline/orchestrate/__tests__/pipeline.test.tsx
@@ -418,6 +418,7 @@ describe('PipelineForm', () => {
       name: 'Existing Pipeline',
       cron: '0 9 * * *',
       isScheduleActive: true,
+      continueOnSyncFailure: false,
       connections: [{ id: 'conn-1', name: 'Connection 1', seq: 1 }],
       transformTasks: [
         { uuid: 'task-1', seq: 1 },
@@ -498,6 +499,7 @@ describe('PipelineForm - Edit Mode Edge Cases', () => {
       name: 'Pipeline With Tasks',
       cron: '0 9 * * *',
       isScheduleActive: true,
+      continueOnSyncFailure: false,
       connections: [{ id: 'conn-1', name: 'Connection 1', seq: 1 }],
       transformTasks: [
         { uuid: 'task-1', seq: 1 },
@@ -533,6 +535,7 @@ describe('PipelineForm - Edit Mode Edge Cases', () => {
       name: 'Custom Order Pipeline',
       cron: '0 14 * * *',
       isScheduleActive: false,
+      continueOnSyncFailure: false,
       connections: [{ id: 'conn-2', name: 'Connection 2', seq: 1 }],
       transformTasks: [
         { uuid: 'task-3', seq: 1 },
@@ -562,6 +565,7 @@ describe('PipelineForm - Edit Mode Edge Cases', () => {
       name: 'DBT Cloud Pipeline',
       cron: '30 10 * * 1,3,5',
       isScheduleActive: true,
+      continueOnSyncFailure: false,
       connections: [
         { id: 'conn-1', name: 'Connection 1', seq: 1 },
         { id: 'conn-2', name: 'Connection 2', seq: 2 },
@@ -596,6 +600,7 @@ describe('PipelineForm - Edit Mode Edge Cases', () => {
       name: 'DBT Cloud No Tasks',
       cron: null,
       isScheduleActive: false,
+      continueOnSyncFailure: false,
       connections: [{ id: 'conn-1', name: 'Connection 1', seq: 1 }],
       transformTasks: [],
     };
@@ -626,6 +631,7 @@ describe('PipelineForm - Edit Mode Edge Cases', () => {
       name: 'Pipeline With Missing Tasks',
       cron: '0 8 * * *',
       isScheduleActive: true,
+      continueOnSyncFailure: false,
       connections: [{ id: 'conn-1', name: 'Connection 1', seq: 1 }],
       transformTasks: [
         { uuid: 'deleted-task-1', seq: 1 },
@@ -685,6 +691,7 @@ describe('PipelineForm - Edit Mode Edge Cases', () => {
       name: 'Mixed Tasks Pipeline',
       cron: '0 9 * * *',
       isScheduleActive: true,
+      continueOnSyncFailure: false,
       connections: [],
       transformTasks: [{ uuid: 'system-default', seq: 1 }],
     };
@@ -715,6 +722,7 @@ describe('PipelineForm - Edit Mode Edge Cases', () => {
       name: 'Status Fail Pipeline',
       cron: '0 9 * * *',
       isScheduleActive: true,
+      continueOnSyncFailure: false,
       connections: [],
       transformTasks: [],
     };
@@ -761,6 +769,7 @@ describe('PipelineForm - Edit Mode Edge Cases', () => {
       name: 'Manual Pipeline',
       cron: null,
       isScheduleActive: false,
+      continueOnSyncFailure: false,
       connections: [{ id: 'conn-1', name: 'Connection 1', seq: 1 }],
       transformTasks: [{ uuid: 'task-1', seq: 1 }],
     };
@@ -785,6 +794,119 @@ describe('PipelineForm - Edit Mode Edge Cases', () => {
     });
 
     expect(screen.queryByTestId('cronTimeOfDay')).not.toBeInTheDocument();
+  });
+
+  it('renders continueOnSyncFailure checkbox unchecked by default in create mode', async () => {
+    const user = userEvent.setup();
+    (usePipelinesHook.usePipeline as jest.Mock).mockReturnValue({
+      pipeline: null,
+      isLoading: false,
+      isError: null,
+      mutate: jest.fn(),
+    });
+    (usePipelinesHook.useTransformTasks as jest.Mock).mockReturnValue({
+      tasks: [],
+      isLoading: false,
+      isError: null,
+      mutate: jest.fn(),
+    });
+    (usePipelinesHook.useConnections as jest.Mock).mockReturnValue({
+      connections: [],
+      isLoading: false,
+      isError: null,
+      mutate: jest.fn(),
+    });
+
+    render(<PipelineForm />);
+
+    // Checkbox is hidden behind Optional toggle
+    expect(screen.queryByTestId('continue-on-sync-failure-checkbox')).not.toBeInTheDocument();
+
+    await user.click(screen.getByTestId('optional-settings-toggle'));
+
+    const checkbox = screen.getByTestId('continue-on-sync-failure-checkbox');
+    expect(checkbox).toBeInTheDocument();
+    expect(checkbox).not.toBeChecked();
+  });
+
+  it('renders continueOnSyncFailure checkbox checked when pipeline has flag set', async () => {
+    const user = userEvent.setup();
+    const pipelineWithFlag: PipelineDetailResponse = {
+      name: 'Pipeline With Flag',
+      cron: '0 9 * * *',
+      isScheduleActive: true,
+      continueOnSyncFailure: true,
+      connections: [{ id: 'conn-1', name: 'Connection 1', seq: 1 }],
+      transformTasks: [],
+    };
+
+    (usePipelinesHook.usePipeline as jest.Mock).mockReturnValue({
+      pipeline: pipelineWithFlag,
+      isLoading: false,
+      isError: null,
+      mutate: jest.fn(),
+    });
+    (usePipelinesHook.useTransformTasks as jest.Mock).mockReturnValue({
+      tasks: [],
+      isLoading: false,
+      isError: null,
+      mutate: jest.fn(),
+    });
+    (usePipelinesHook.useConnections as jest.Mock).mockReturnValue({
+      connections: [],
+      isLoading: false,
+      isError: null,
+      mutate: jest.fn(),
+    });
+
+    render(<PipelineForm deploymentId="test-dep" />);
+
+    await user.click(screen.getByTestId('optional-settings-toggle'));
+
+    await waitFor(() => {
+      const checkbox = screen.getByTestId('continue-on-sync-failure-checkbox');
+      expect(checkbox).toBeChecked();
+    });
+  });
+
+  it('defaults continueOnSyncFailure to false for existing pipelines without the flag', async () => {
+    const user = userEvent.setup();
+    const oldPipeline: PipelineDetailResponse = {
+      name: 'Old Pipeline',
+      cron: '0 9 * * *',
+      isScheduleActive: true,
+      continueOnSyncFailure: false,
+      connections: [],
+      transformTasks: [],
+    };
+
+    (usePipelinesHook.usePipeline as jest.Mock).mockReturnValue({
+      pipeline: oldPipeline,
+      isLoading: false,
+      isError: null,
+      mutate: jest.fn(),
+    });
+    (usePipelinesHook.useTransformTasks as jest.Mock).mockReturnValue({
+      tasks: [],
+      isLoading: false,
+      isError: null,
+      mutate: jest.fn(),
+    });
+    (usePipelinesHook.useConnections as jest.Mock).mockReturnValue({
+      connections: [],
+      isLoading: false,
+      isError: null,
+      mutate: jest.fn(),
+    });
+
+    render(<PipelineForm deploymentId="old-dep" />);
+
+    await user.click(screen.getByTestId('optional-settings-toggle'));
+
+    await waitFor(() => {
+      const checkbox = screen.getByTestId('continue-on-sync-failure-checkbox');
+      expect(checkbox).not.toBeChecked();
+    });
   });
 });
 

--- a/components/pipeline/orchestrate/pipeline-form.tsx
+++ b/components/pipeline/orchestrate/pipeline-form.tsx
@@ -27,8 +27,8 @@ import type {
   ConnectionOption,
   WeekdayOption,
   PipelineDetailResponse,
-  Connection,
 } from '@/types/pipeline';
+import type { Connection } from '@/types/connections';
 import { TaskSequence } from './task-sequence';
 import {
   convertToCronExpression,

--- a/components/pipeline/orchestrate/pipeline-form.tsx
+++ b/components/pipeline/orchestrate/pipeline-form.tsx
@@ -4,7 +4,7 @@ import { useState, useMemo, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
 import { useSWRConfig } from 'swr';
 import { useForm, Controller } from 'react-hook-form';
-import { Loader2 } from 'lucide-react';
+import { Loader2, ChevronDown } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -93,6 +93,7 @@ function computeInitialValues(
         tasks: [],
         cronDaysOfWeek: [],
         cronTimeOfDay: '',
+        continueOnSyncFailure: false,
       },
       runTransformTasks: false,
     };
@@ -134,6 +135,7 @@ function computeInitialValues(
         label: WEEKDAYS[day],
       })),
       cronTimeOfDay: utcTimeToLocal(cronObject.timeOfDay),
+      continueOnSyncFailure: pipeline.continueOnSyncFailure ?? false,
     },
     runTransformTasks: tasksToApply.length > 0,
   };
@@ -243,6 +245,7 @@ function PipelineFormContent({
           connections: selectedConns,
           cron: cronExpression,
           transformTasks,
+          continueOnSyncFailure: data.continueOnSyncFailure,
         });
 
         // Update schedule status if changed - compare against original value
@@ -274,6 +277,7 @@ function PipelineFormContent({
           connections: selectedConns,
           cron: cronExpression,
           transformTasks,
+          continueOnSyncFailure: data.continueOnSyncFailure,
         });
 
         toastSuccess.created('Pipeline');
@@ -371,6 +375,7 @@ function PipelineFormContent({
                   />
                 )}
               />
+              <OptionalSettings control={control} />
             </div>
 
             {/* Transform tasks */}
@@ -503,6 +508,52 @@ function PipelineFormContent({
         </div>
       </div>
     </form>
+  );
+}
+
+function OptionalSettings({ control }: { control: any }) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div className="mt-4">
+      <button
+        type="button"
+        className="flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground transition-colors"
+        onClick={() => setOpen(!open)}
+        data-testid="optional-settings-toggle"
+      >
+        <ChevronDown className={`h-3.5 w-3.5 transition-transform ${open ? '' : '-rotate-90'}`} />
+        Optional
+      </button>
+      {open && (
+        <div className="mt-2">
+          <Controller
+            name="continueOnSyncFailure"
+            control={control}
+            render={({ field }) => (
+              <div className="flex items-start gap-2">
+                <Checkbox
+                  id="continue-on-sync-failure"
+                  data-testid="continue-on-sync-failure-checkbox"
+                  checked={field.value}
+                  onCheckedChange={field.onChange}
+                  className="mt-0.5"
+                />
+                <div>
+                  <Label htmlFor="continue-on-sync-failure" className="text-sm">
+                    Continue syncing remaining connections if one fails
+                  </Label>
+                  <p className="text-xs text-muted-foreground mt-0.5">
+                    All syncs will be attempted even if some fail. In case of any errors, transform
+                    tasks will not run and the errors will be raised at the end.
+                  </p>
+                </div>
+              </div>
+            )}
+          />
+        </div>
+      )}
+    </div>
   );
 }
 

--- a/components/pipeline/orchestrate/pipeline-form.tsx
+++ b/components/pipeline/orchestrate/pipeline-form.tsx
@@ -352,6 +352,9 @@ function PipelineFormContent({
             {/* Connections */}
             <div className="space-y-2">
               <Label className="text-[15px] font-medium">Connections</Label>
+              <p className="text-sm text-muted-foreground">
+                Connections are run in the sequence you select them.
+              </p>
               <Controller
                 name="connections"
                 control={control}
@@ -523,7 +526,7 @@ function OptionalSettings({ control }: { control: any }) {
         data-testid="advanced-settings-toggle"
       >
         <ChevronDown className={`h-3.5 w-3.5 transition-transform ${open ? '' : '-rotate-90'}`} />
-        Advanced
+        Advanced (optional)
       </button>
       {open && (
         <div className="mt-2">
@@ -544,8 +547,8 @@ function OptionalSettings({ control }: { control: any }) {
                     Continue syncing remaining connections if one fails
                   </Label>
                   <p className="text-xs text-muted-foreground mt-0.5">
-                    All syncs will be attempted even if some fail. In case of any errors, transform
-                    tasks will not run and the errors will be raised at the end.
+                    All connections will be attempted even if some fail. In case of any errors,
+                    transform tasks will not run and the errors will be raised at the end.
                   </p>
                 </div>
               </div>

--- a/components/pipeline/orchestrate/pipeline-form.tsx
+++ b/components/pipeline/orchestrate/pipeline-form.tsx
@@ -520,10 +520,10 @@ function OptionalSettings({ control }: { control: any }) {
         type="button"
         className="flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground transition-colors"
         onClick={() => setOpen(!open)}
-        data-testid="optional-settings-toggle"
+        data-testid="advanced-settings-toggle"
       >
         <ChevronDown className={`h-3.5 w-3.5 transition-transform ${open ? '' : '-rotate-90'}`} />
-        Optional
+        Advanced
       </button>
       {open && (
         <div className="mt-2">

--- a/hooks/__tests__/usePipelines.test.ts
+++ b/hooks/__tests__/usePipelines.test.ts
@@ -187,6 +187,7 @@ describe('Pipeline Mutation Functions', () => {
       connections: [{ id: 'conn-1', seq: 1 }],
       cron: '0 9 * * *',
       transformTasks: [{ uuid: 'task-1', seq: 1 }],
+      continueOnSyncFailure: false,
     });
     expect(apiPost).toHaveBeenCalledWith('/api/prefect/v1/flows/', expect.any(Object));
     expect(createResult.name).toBe('New Pipeline');
@@ -198,6 +199,7 @@ describe('Pipeline Mutation Functions', () => {
       connections: [],
       cron: '',
       transformTasks: [],
+      continueOnSyncFailure: true,
     });
     expect(apiPut).toHaveBeenCalledWith('/api/prefect/v1/flows/dep-id', expect.any(Object));
 

--- a/hooks/api/usePipelines.ts
+++ b/hooks/api/usePipelines.ts
@@ -3,12 +3,12 @@ import { apiGet, apiPost, apiPut, apiDelete } from '@/lib/api';
 import {
   Pipeline,
   TransformTask,
-  Connection,
   DeploymentRun,
   PipelineDetailResponse,
   TaskProgressResponse,
   DashboardPipeline,
 } from '@/types/pipeline';
+import type { Connection } from '@/types/connections';
 import {
   POLLING_INTERVAL_WHEN_LOCKED,
   POLLING_INTERVAL_IDLE,

--- a/hooks/api/usePipelines.ts
+++ b/hooks/api/usePipelines.ts
@@ -138,6 +138,7 @@ export async function createPipeline(data: {
   connections: { id: string; seq: number }[];
   cron: string;
   transformTasks: { uuid: string; seq: number }[];
+  continueOnSyncFailure: boolean;
 }): Promise<{ name: string }> {
   return apiPost('/api/prefect/v1/flows/', data);
 }
@@ -152,6 +153,7 @@ export async function updatePipeline(
     connections: { id: string; seq: number }[];
     cron: string;
     transformTasks: { uuid: string; seq: number }[];
+    continueOnSyncFailure: boolean;
   }
 ): Promise<void> {
   return apiPut(`/api/prefect/v1/flows/${deploymentId}`, data);

--- a/types/pipeline.ts
+++ b/types/pipeline.ts
@@ -98,6 +98,7 @@ export interface PipelineFormData {
   cron: ScheduleOption | null;
   cronDaysOfWeek: WeekdayOption[];
   cronTimeOfDay: string;
+  continueOnSyncFailure: boolean;
 }
 
 // API response types
@@ -105,6 +106,7 @@ export interface PipelineDetailResponse {
   name: string;
   cron: string | null;
   isScheduleActive: boolean;
+  continueOnSyncFailure: boolean;
   connections: Array<{
     id: string;
     name: string;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional "Continue syncing remaining connections if one fails" setting in pipeline configuration, located in the Advanced (optional) section.
  * The setting is off by default for new and existing pipelines and can be toggled per pipeline.

* **Tests**
  * Test coverage updated to include the new optional setting and its create/edit behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DalgoT4D/webapp_v2/pull/300)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->