### PR TITLE
cleanup: remove root-level layout_config and components from frontend…

### DIFF
--- a/app/dashboards/create/page.tsx
+++ b/app/dashboards/create/page.tsx
@@ -69,8 +69,6 @@ export default function CreateDashboardPage() {
         setDashboardData({
           title: dashboard.title,
           grid_columns: dashboard.grid_columns || 12,
-          layout_config: dashboard.layout_config || [],
-          components: dashboard.components || {},
           tabs: dashboard.tabs || [],
         });
 

--- a/components/dashboard/DashboardMiniPreview.tsx
+++ b/components/dashboard/DashboardMiniPreview.tsx
@@ -12,41 +12,17 @@ export function DashboardMiniPreview({ dashboardData, className }: DashboardMini
   // This is a simplified client-side dashboard renderer
   // Similar to how charts render using MiniChart
 
-  // Handle different dashboard data structures and ensure we have an array
-  let components: any[] = [];
-
-  if (
-    dashboardData?.layout_config?.components &&
-    Array.isArray(dashboardData.layout_config.components)
-  ) {
-    components = dashboardData.layout_config.components;
-  } else if (Array.isArray(dashboardData?.layout_config)) {
-    components = dashboardData.layout_config;
-  } else if (dashboardData?.components && Array.isArray(dashboardData.components)) {
-    components = dashboardData.components;
-  } else if (dashboardData?.components && typeof dashboardData.components === 'object') {
-    // Handle case where components is an object - convert to array
-    components = Object.values(dashboardData.components);
-  } else {
-    // No valid component array found - create fallback visualization
-    console.log('❌ No valid components found, using fallback');
-    components = [
-      { id: 1, w: 2, h: 1 },
-      { id: 2, w: 2, h: 1 },
-      { id: 3, w: 4, h: 1 },
-      { id: 4, w: 3, h: 1 },
-    ];
-  }
-
-  // Ensure components is definitely an array
-  if (!Array.isArray(components)) {
-    console.log('❌ Components is not an array, creating fallback');
-    components = [
-      { id: 1, w: 2, h: 1 },
-      { id: 2, w: 2, h: 1 },
-      { id: 3, w: 4, h: 1 },
-    ];
-  }
+  const activeTab = dashboardData?.tabs?.[0];
+  const tabComponents = activeTab?.components;
+  const components: any[] =
+    tabComponents && typeof tabComponents === 'object'
+      ? Object.values(tabComponents)
+      : [
+          { id: 1, w: 2, h: 1 },
+          { id: 2, w: 2, h: 1 },
+          { id: 3, w: 4, h: 1 },
+          { id: 4, w: 3, h: 1 },
+        ];
 
   const gridColumns = dashboardData?.grid_columns || 12;
 

--- a/hooks/api/useDashboards.ts
+++ b/hooks/api/useDashboards.ts
@@ -12,9 +12,7 @@ export interface Dashboard {
   grid_columns: number;
   target_screen_size?: 'desktop' | 'tablet' | 'mobile' | 'a4'; // Target screen size for design
   filter_layout?: 'vertical' | 'horizontal'; // Filter layout position
-  layout_config: any;
   responsive_layouts?: any; // Optional responsive layouts for different breakpoints
-  components: any;
   tabs: DashboardTabData[];
   is_published: boolean;
   published_at?: string;


### PR DESCRIPTION
## Summary

- Permanently removes deprecated root-level `layout_config` and `components` fields from the Dashboard system
- All dashboard data now lives exclusively in `dashboard.tabs[].layout_config` and `dashboard.tabs[].components`
- Adds `cleanup_frozen_dashboard_root_fields` management command to clean up existing ReportSnapshot JSON blobs

## Migration steps (on deploy)

1. Run data migration: `python manage.py cleanup_frozen_dashboard_root_fields`
2. Run schema migration: `python manage.py migrate ddpui 0161`

## Test plan

- [ ] All 1592 backend tests pass (`uv run pytest ddpui/tests/ --ignore=ddpui/tests/integration_tests`)
- [ ] Create a dashboard — verify no `layout_config`/`components` in API response
- [ ] Open an existing report — verify it renders correctly
- [ ] Duplicate a dashboard — verify tabs are copied correctly


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified dashboard initialization process by streamlining the data structure used during dashboard creation.
  * Optimized dashboard preview component to reduce complexity in handling dashboard data.
  * Updated dashboard data model to better reflect current system requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->