### PR TITLE
fix: chart UI bugs — save dialog title, pagination, map styling, inge…

### DIFF
--- a/app/charts/[id]/edit/page.tsx
+++ b/app/charts/[id]/edit/page.tsx
@@ -1809,7 +1809,7 @@ function EditChartPageContent() {
       <SaveOptionsDialog
         open={showSaveDialog}
         onOpenChange={setShowSaveDialog}
-        originalTitle={chart?.title || ''}
+        originalTitle={formData.title || ''}
         onSaveExisting={handleUpdateExisting}
         onSaveAsNew={handleSaveAsNew}
         isLoading={isMutating || isCreating}

--- a/app/charts/page.tsx
+++ b/app/charts/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useMemo, useCallback } from 'react';
+import { useState, useMemo, useCallback, useEffect } from 'react';
 import {
   Plus,
   BarChart2,
@@ -119,17 +119,11 @@ export default function ChartsPage() {
   const {
     data: allCharts,
     total: apiTotal,
-    page: apiPage,
-    pageSize: apiPageSize,
     totalPages: apiTotalPages,
     isLoading,
     isError,
     mutate,
-  } = useCharts({
-    page: currentPage,
-    pageSize,
-    // Remove search and chartType - we'll handle filtering client-side
-  });
+  } = useCharts({ page: currentPage, pageSize });
   const { trigger: deleteChart } = useDeleteChart();
   const { trigger: bulkDeleteCharts } = useBulkDeleteCharts();
   const { trigger: createChart } = useCreateChart();
@@ -932,12 +926,25 @@ export default function ChartsPage() {
     );
   };
 
-  // Calculate pagination for filtered results
-  const startIndex = (currentPage - 1) * pageSize;
-  const endIndex = startIndex + pageSize;
-  const paginatedCharts = filteredAndSortedCharts.slice(startIndex, endIndex);
-  const total = filteredAndSortedCharts.length;
-  const totalPages = Math.ceil(filteredAndSortedCharts.length / pageSize);
+  // Reset to page 1 whenever filters or sort changes
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [
+    nameFilters.text,
+    nameFilters.showFavorites,
+    dataSourceFilters,
+    chartTypeFilters,
+    dateFilters.range,
+    dateFilters.customStart,
+    dateFilters.customEnd,
+    sortBy,
+    sortOrder,
+  ]);
+
+  // Server handles pagination; use its values for display
+  const paginatedCharts = filteredAndSortedCharts;
+  const total = apiTotal;
+  const totalPages = apiTotalPages;
 
   if (isError) {
     return (

--- a/app/charts/page.tsx
+++ b/app/charts/page.tsx
@@ -941,6 +941,13 @@ export default function ChartsPage() {
     sortOrder,
   ]);
 
+  // Clamp currentPage if total pages shrinks (e.g. after deletes)
+  useEffect(() => {
+    if (apiTotalPages > 0 && currentPage > apiTotalPages) {
+      setCurrentPage(apiTotalPages);
+    }
+  }, [apiTotalPages, currentPage]);
+
   // Server handles pagination; use its values for display
   const paginatedCharts = filteredAndSortedCharts;
   const total = apiTotal;

--- a/components/charts/map/MapCustomizations.tsx
+++ b/components/charts/map/MapCustomizations.tsx
@@ -186,63 +186,6 @@ export function MapCustomizations({ formData, onFormDataChange }: MapCustomizati
           </div>
         </CardContent>
       </Card>
-
-      {/* Animation & Effects */}
-      <Card>
-        <CardHeader>
-          <CardTitle className="text-base">Animation & Effects</CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-4">
-          <div>
-            <Label className="text-sm font-medium">Border Width</Label>
-            <p className="text-xs text-muted-foreground mb-2">Width of region borders</p>
-            <Select
-              value={customizations.borderWidth?.toString() || '1'}
-              onValueChange={(value) => updateCustomization('borderWidth', parseInt(value))}
-            >
-              <SelectTrigger>
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="0">No Border</SelectItem>
-                <SelectItem value="1">Thin</SelectItem>
-                <SelectItem value="2">Medium</SelectItem>
-                <SelectItem value="3">Thick</SelectItem>
-              </SelectContent>
-            </Select>
-          </div>
-
-          <div>
-            <Label className="text-sm font-medium">Border Color</Label>
-            <Select
-              value={customizations.borderColor || '#333'}
-              onValueChange={(value) => updateCustomization('borderColor', value)}
-            >
-              <SelectTrigger>
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="#333">Dark Gray</SelectItem>
-                <SelectItem value="#666">Medium Gray</SelectItem>
-                <SelectItem value="#999">Light Gray</SelectItem>
-                <SelectItem value="#fff">White</SelectItem>
-                <SelectItem value="#000">Black</SelectItem>
-              </SelectContent>
-            </Select>
-          </div>
-
-          <div className="flex items-center justify-between">
-            <div>
-              <Label className="text-sm font-medium">Animation</Label>
-              <p className="text-xs text-muted-foreground">Enable smooth transitions</p>
-            </div>
-            <Switch
-              checked={customizations.animation !== false}
-              onCheckedChange={(checked) => updateCustomization('animation', checked)}
-            />
-          </div>
-        </CardContent>
-      </Card>
     </div>
   );
 }

--- a/components/charts/map/MapPreview.tsx
+++ b/components/charts/map/MapPreview.tsx
@@ -427,8 +427,8 @@ export function MapPreview({
               // Configure how regions without data should appear (default styling)
               itemStyle: {
                 areaColor: '#f5f5f5', // Light gray for regions without data
-                borderColor: safeCustomizations.borderColor || '#333',
-                borderWidth: safeCustomizations.borderWidth || 0.5,
+                borderColor: '#000',
+                borderWidth: 0,
               },
               label: {
                 show: safeCustomizations.showLabels === true,
@@ -445,8 +445,8 @@ export function MapPreview({
                 },
               },
               // Animation settings
-              animation: safeCustomizations.animation !== false,
-              animationDuration: safeCustomizations.animation !== false ? 1000 : 0,
+              animation: true,
+              animationDuration: 1000,
               // Use enhanced data with individual colors when legend is disabled
               ...(safeCustomizations.showLegend === false
                 ? {

--- a/components/charts/map/__tests__/MapCustomizations.test.tsx
+++ b/components/charts/map/__tests__/MapCustomizations.test.tsx
@@ -6,7 +6,6 @@
  * - Interactive feature toggles (tooltip, legend, selection)
  * - Data handling configuration (null value labels)
  * - Visual elements (legend position, region names, hover effects)
- * - Animation and border customizations
  *
  * Architecture: Tests UI rendering and onChange callbacks for all customization options
  */
@@ -29,9 +28,6 @@ describe('MapCustomizations', () => {
       legendPosition: 'left',
       showLabels: false,
       emphasis: true,
-      borderWidth: 1,
-      borderColor: '#333',
-      animation: true,
     },
   };
 
@@ -53,7 +49,6 @@ describe('MapCustomizations', () => {
       expect(screen.getByText('Interactive Features')).toBeInTheDocument();
       expect(screen.getByText('Data Handling')).toBeInTheDocument();
       expect(screen.getByText('Visual Elements')).toBeInTheDocument();
-      expect(screen.getByText('Animation & Effects')).toBeInTheDocument();
     });
 
     it('should render with empty customizations object', () => {
@@ -355,76 +350,6 @@ describe('MapCustomizations', () => {
   });
 
   /**
-   * Animation & Effects Configuration
-   */
-  describe('Animation & Effects', () => {
-    it('should render border width selector', () => {
-      render(
-        <MapCustomizations formData={defaultFormData} onFormDataChange={mockOnFormDataChange} />
-      );
-
-      expect(screen.getByText('Border Width')).toBeInTheDocument();
-      expect(screen.getByText('Width of region borders')).toBeInTheDocument();
-
-      const borderWidthLabel = screen.getByText('Border Width');
-      const selectTrigger =
-        borderWidthLabel.parentElement?.parentElement?.querySelector('[role="combobox"]');
-      expect(selectTrigger).toBeInTheDocument();
-    });
-
-    it('should render border color selector', () => {
-      render(
-        <MapCustomizations formData={defaultFormData} onFormDataChange={mockOnFormDataChange} />
-      );
-
-      expect(screen.getByText('Border Color')).toBeInTheDocument();
-
-      const borderColorLabel = screen.getByText('Border Color');
-      const selectTrigger = borderColorLabel.parentElement?.querySelector('[role="combobox"]');
-      expect(selectTrigger).toBeInTheDocument();
-    });
-
-    it('should toggle animation', async () => {
-      const user = userEvent.setup();
-      render(
-        <MapCustomizations formData={defaultFormData} onFormDataChange={mockOnFormDataChange} />
-      );
-
-      const animationLabel = screen.getByText('Animation');
-      const animationSwitch = animationLabel.parentElement?.parentElement?.querySelector('button');
-
-      expect(animationSwitch).toBeInTheDocument();
-      await user.click(animationSwitch!);
-
-      expect(mockOnFormDataChange).toHaveBeenCalledWith({
-        ...defaultFormData,
-        customizations: {
-          ...defaultFormData.customizations,
-          animation: false,
-        },
-      });
-    });
-
-    it('should display border width options with proper descriptions', () => {
-      render(
-        <MapCustomizations formData={defaultFormData} onFormDataChange={mockOnFormDataChange} />
-      );
-
-      // Component defines border width options: No Border (0), Thin (1), Medium (2), Thick (3)
-      expect(screen.getByText('Border Width')).toBeInTheDocument();
-    });
-
-    it('should display border color options', () => {
-      render(
-        <MapCustomizations formData={defaultFormData} onFormDataChange={mockOnFormDataChange} />
-      );
-
-      // Component defines border colors: Dark Gray, Medium Gray, Light Gray, White, Black
-      expect(screen.getByText('Border Color')).toBeInTheDocument();
-    });
-  });
-
-  /**
    * Integration Tests
    */
   describe('Integration', () => {
@@ -483,18 +408,18 @@ describe('MapCustomizations', () => {
         <MapCustomizations formData={defaultFormData} onFormDataChange={mockOnFormDataChange} />
       );
 
-      const animationLabel = screen.getByText('Animation');
-      const animationSwitch = animationLabel.parentElement?.parentElement?.querySelector('button');
+      const tooltipLabel = screen.getByText('Show Tooltip');
+      const tooltipSwitch = tooltipLabel.parentElement?.parentElement?.querySelector('button');
 
-      expect(animationSwitch).toBeInTheDocument();
-      await user.click(animationSwitch!);
+      expect(tooltipSwitch).toBeInTheDocument();
+      await user.click(tooltipSwitch!);
 
       const callArg = mockOnFormDataChange.mock.calls[0][0];
 
       // Verify structure
       expect(callArg).toHaveProperty('customizations');
-      expect(callArg.customizations).toHaveProperty('animation');
-      expect(typeof callArg.customizations.animation).toBe('boolean');
+      expect(callArg.customizations).toHaveProperty('showTooltip');
+      expect(typeof callArg.customizations.showTooltip).toBe('boolean');
     });
   });
 
@@ -517,7 +442,6 @@ describe('MapCustomizations', () => {
       expect(screen.getByText('Display color scale legend')).toBeInTheDocument();
       expect(screen.getByText('Allow clicking to select regions')).toBeInTheDocument();
       expect(screen.getByText('Display region labels on the map')).toBeInTheDocument();
-      expect(screen.getByText('Enable smooth transitions')).toBeInTheDocument();
     });
 
     it('should handle formData with minimal properties', () => {

--- a/components/charts/types/__tests__/MapChartCustomizations.test.tsx
+++ b/components/charts/types/__tests__/MapChartCustomizations.test.tsx
@@ -24,7 +24,6 @@ describe('MapChartCustomizations', () => {
     expect(screen.getByText('Interactive Features')).toBeInTheDocument();
     expect(screen.getByText('Data Handling')).toBeInTheDocument();
     expect(screen.getByText('Visual Elements')).toBeInTheDocument();
-    expect(screen.getByText('Animation & Effects')).toBeInTheDocument();
   });
 
   it('should render interactive features with default values and descriptions', () => {
@@ -52,14 +51,11 @@ describe('MapChartCustomizations', () => {
     expect(mockUpdateCustomization).toHaveBeenCalledWith('nullValueLabel', 'No Datax');
   });
 
-  it('should render visual elements and animation settings', () => {
+  it('should render visual elements', () => {
     render(<MapChartCustomizations {...defaultProps} />);
 
     expect(screen.getByText('Legend Position')).toBeInTheDocument();
     expect(screen.getByText('Show Region Names')).toBeInTheDocument();
-    expect(screen.getByText('Border Width')).toBeInTheDocument();
-    expect(screen.getByText('Border Color')).toBeInTheDocument();
-    expect(screen.getByText('Enable smooth transitions')).toBeInTheDocument();
   });
 
   it('should handle show region names toggle', async () => {

--- a/components/charts/types/map/MapChartCustomizations.tsx
+++ b/components/charts/types/map/MapChartCustomizations.tsx
@@ -174,66 +174,6 @@ export function MapChartCustomizations({
           </div>
         </CardContent>
       </Card>
-
-      {/* Animation & Effects */}
-      <Card>
-        <CardHeader>
-          <CardTitle className="text-base">Animation & Effects</CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-4">
-          <div>
-            <Label className="text-sm font-medium">Border Width</Label>
-            <p className="text-xs text-muted-foreground mb-2">Width of region borders</p>
-            <Select
-              value={customizations.borderWidth?.toString() || '1'}
-              onValueChange={(value) => updateCustomization('borderWidth', parseInt(value))}
-              disabled={disabled}
-            >
-              <SelectTrigger>
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="0">No Border</SelectItem>
-                <SelectItem value="1">Thin</SelectItem>
-                <SelectItem value="2">Medium</SelectItem>
-                <SelectItem value="3">Thick</SelectItem>
-              </SelectContent>
-            </Select>
-          </div>
-
-          <div>
-            <Label className="text-sm font-medium">Border Color</Label>
-            <Select
-              value={customizations.borderColor || '#333'}
-              onValueChange={(value) => updateCustomization('borderColor', value)}
-              disabled={disabled}
-            >
-              <SelectTrigger>
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="#333">Dark Gray</SelectItem>
-                <SelectItem value="#666">Medium Gray</SelectItem>
-                <SelectItem value="#999">Light Gray</SelectItem>
-                <SelectItem value="#fff">White</SelectItem>
-                <SelectItem value="#000">Black</SelectItem>
-              </SelectContent>
-            </Select>
-          </div>
-
-          <div className="flex items-center justify-between">
-            <div>
-              <Label className="text-sm font-medium">Animation</Label>
-              <p className="text-xs text-muted-foreground">Enable smooth transitions</p>
-            </div>
-            <Switch
-              checked={customizations.animation !== false}
-              onCheckedChange={(checked) => updateCustomization('animation', checked)}
-              disabled={disabled}
-            />
-          </div>
-        </CardContent>
-      </Card>
     </div>
   );
 }

--- a/components/connectors/fields/FieldLabel.tsx
+++ b/components/connectors/fields/FieldLabel.tsx
@@ -51,7 +51,10 @@ export function FieldLabel({ title, required, description, htmlFor }: FieldLabel
                   data-testid={`field-info-${htmlFor}`}
                 />
               </TooltipTrigger>
-              <TooltipContent side="right" className="max-w-xs text-xs">
+              <TooltipContent
+                side="right"
+                className="max-w-xs text-xs [&_a]:underline [&_a]:opacity-80 [&_a]:cursor-pointer"
+              >
                 <p dangerouslySetInnerHTML={{ __html: sanitizedDescription }} />
               </TooltipContent>
             </Tooltip>


### PR DESCRIPTION
## Summary

- **DALGO-1198**: Save as New Chart dialog was pre-filling the old chart title (from API) instead of the current edited title
- **DALGO-1303**: Charts list pagination always showed "1 of 1" — page was ignoring server-side total/totalPages and recomputing from the local filtered array instead
- **DALGO-556**: Removed the Animation & Effects section from map styling (border width, border color, animation controls). Hardcoded intelligent defaults in MapPreview: borderColor `#000`, borderWidth `0`, animation `true`
- **DALGO-590**: Links inside the (i) info tooltip on ingest source config fields were not visually styled as links — added underline, opacity and pointer cursor via `[&_a]` Tailwind selector

## Test plan

- [ ] Create a new chart, edit its title, click Save → Save as New Chart — confirm dialog pre-fills the edited title, not the original
- [ ] With 6+ charts, confirm pagination shows correct count (e.g. "1–6 of 6") and correct pages — change filters/sort and confirm page resets to 1
- [ ] Open a map chart in edit mode → Styling tab — confirm Animation & Effects section is gone; confirm map still renders with black border and animation
- [ ] Go to Ingest → New Source → select any source type → hover the (i) icon on any field — confirm links appear underlined and clickable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Save dialog now shows the title you’re actively editing
  * Pagination resets to page 1 when filters or sort change and clamps to available pages

* **Changes**
  * Map customizations: removed the "Animation & Effects" controls (border/animation options)
  * Map preview: map borders, color, and animation use fixed, consistent values

* **Style**
  * Updated tooltip styling for field labels

* **Tests**
  * Updated map customization tests to reflect removed animation options

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DalgoT4D/webapp_v2/pull/305?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->