### PR TITLE
Fix/dashboard filter order and csv download

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,8 @@ node_modules/
 /blob-report/
 /playwright/.cache/
 /playwright/.auth/
+/.playwright-mcp/
+/dash1-view.png
 
 # Sentry Config File
 .env.sentry-build-plugin

--- a/components/dashboard/chart-element-view.tsx
+++ b/components/dashboard/chart-element-view.tsx
@@ -444,20 +444,13 @@ export function ChartElementView({
                       value,
                     }))
                   : []),
-                // Include resolved dashboard filters for all chart types
-                ...formatAsChartFilters(
-                  resolvedDashboardFilters.filter(
-                    (filter) =>
-                      filter.schema_name === effectiveChart.schema_name &&
-                      filter.table_name === effectiveChart.table_name
-                  )
-                ),
               ],
               pagination: effectiveChart.extra_config?.pagination,
               sort: effectiveChart.extra_config?.sort,
             },
-            // dashboard_filters omitted — resolved filters are in
-            // extra_config.filters; CSV endpoint can't resolve raw filter IDs.
+            // Dashboard filters are sent via the `dashboard_filters` query
+            // string and resolved server-side (same as the chart-data and
+            // table-preview endpoints), so they are not injected here.
           }
         : null,
     [effectiveChart, tableDrillDownState, resolvedDashboardFilters, dashboardFilters]

--- a/components/dashboard/chart-element-view.tsx
+++ b/components/dashboard/chart-element-view.tsx
@@ -456,16 +456,8 @@ export function ChartElementView({
               pagination: effectiveChart.extra_config?.pagination,
               sort: effectiveChart.extra_config?.sort,
             },
-            // Dashboard filters intentionally omitted from the payload body.
-            // The synthetic {filter_id, value} format isn't compatible with
-            // backend apply_dashboard_filters() (which expects resolved filters
-            // with `column`/`type` keys and crashes with KeyError otherwise —
-            // this broke CSV download). The resolved filters are already
-            // included in extra_config.filters above via formatAsChartFilters.
-            // Endpoints that need raw filter IDs (chart-data-preview,
-            // chart-data-preview/total-rows) receive them via the
-            // `dashboard_filters` query-string parameter set by the SWR
-            // fetchers below.
+            // dashboard_filters omitted — resolved filters are in
+            // extra_config.filters; CSV endpoint can't resolve raw filter IDs.
           }
         : null,
     [effectiveChart, tableDrillDownState, resolvedDashboardFilters, dashboardFilters]

--- a/components/dashboard/chart-element-view.tsx
+++ b/components/dashboard/chart-element-view.tsx
@@ -456,16 +456,16 @@ export function ChartElementView({
               pagination: effectiveChart.extra_config?.pagination,
               sort: effectiveChart.extra_config?.sort,
             },
-            // Dashboard filters passed separately (skip in report mode — synthetic
-            // filter IDs can't be resolved by the backend; extra_config.filters
-            // already contains the resolved filters via formatAsChartFilters above)
-            dashboard_filters:
-              !frozenChartConfig && Object.keys(dashboardFilters).length > 0
-                ? Object.entries(dashboardFilters).map(([filter_id, value]) => ({
-                    filter_id,
-                    value,
-                  }))
-                : undefined,
+            // Dashboard filters intentionally omitted from the payload body.
+            // The synthetic {filter_id, value} format isn't compatible with
+            // backend apply_dashboard_filters() (which expects resolved filters
+            // with `column`/`type` keys and crashes with KeyError otherwise —
+            // this broke CSV download). The resolved filters are already
+            // included in extra_config.filters above via formatAsChartFilters.
+            // Endpoints that need raw filter IDs (chart-data-preview,
+            // chart-data-preview/total-rows) receive them via the
+            // `dashboard_filters` query-string parameter set by the SWR
+            // fetchers below.
           }
         : null,
     [effectiveChart, tableDrillDownState, resolvedDashboardFilters, dashboardFilters]

--- a/components/dashboard/chart-element-view.tsx
+++ b/components/dashboard/chart-element-view.tsx
@@ -1588,15 +1588,19 @@ export function ChartElementView({
         description: 'Fetching chart data from server',
       });
 
-      // Use appropriate endpoint based on public mode
+      // Pass dashboard filters as query string so the backend can resolve them
+      // against the chart's table (mirrors the chart-data-preview pattern).
+      const csvQueryString =
+        !frozenChartConfig && Object.keys(dashboardFilters).length > 0
+          ? `?dashboard_filters=${encodeURIComponent(JSON.stringify(dashboardFilters))}`
+          : '';
+
       let blob: Blob;
       if (isPublicMode && publicToken) {
-        // Public dashboard - use unauthenticated endpoint
-        const publicUrl = `/api/v1/public/dashboards/${publicToken}/charts/${chartId}/download-csv/`;
+        const publicUrl = `/api/v1/public/dashboards/${publicToken}/charts/${chartId}/download-csv/${csvQueryString}`;
         blob = await apiPostBinary(publicUrl, chartDataPayload);
       } else {
-        // Authenticated dashboard - use authenticated endpoint
-        blob = await apiPostBinary('/api/charts/download-csv/', chartDataPayload);
+        blob = await apiPostBinary(`/api/charts/download-csv/${csvQueryString}`, chartDataPayload);
       }
 
       // Generate filename

--- a/components/dashboard/dashboard-builder-v2.tsx
+++ b/components/dashboard/dashboard-builder-v2.tsx
@@ -494,6 +494,13 @@ export const DashboardBuilderV2 = forwardRef<DashboardBuilderV2Ref, DashboardBui
     const [description, setDescription] = useState(initialData?.description || '');
     const [isEditingTitle, setIsEditingTitle] = useState(isNewDashboard || false);
     const [isEditingDescription, setIsEditingDescription] = useState(false);
+    // Snapshot of description captured when edit mode opens, used to revert on
+    // Escape. Avoids reverting to stale `initialData` after saves.
+    const originalDescriptionRef = useRef(description);
+    const beginEditDescription = useCallback(() => {
+      originalDescriptionRef.current = description;
+      setIsEditingDescription(true);
+    }, [description]);
 
     // Tabs state - initialize from initialData or create default
     const [tabsData, setTabsData] = useState<DashboardTabsData>(() => {
@@ -1816,7 +1823,7 @@ export const DashboardBuilderV2 = forwardRef<DashboardBuilderV2Ref, DashboardBui
                           saveDashboard();
                         }
                         if (e.key === 'Escape') {
-                          setDescription(initialData?.description || '');
+                          setDescription(originalDescriptionRef.current);
                           setIsEditingDescription(false);
                         }
                       }}
@@ -1826,10 +1833,7 @@ export const DashboardBuilderV2 = forwardRef<DashboardBuilderV2Ref, DashboardBui
                       }}
                     />
                   ) : (
-                    <div
-                      className="cursor-pointer min-w-0"
-                      onClick={() => setIsEditingDescription(true)}
-                    >
+                    <div className="cursor-pointer min-w-0" onClick={beginEditDescription}>
                       {description ? (
                         <p className="text-xs text-gray-600 truncate">{description}</p>
                       ) : (
@@ -2137,7 +2141,7 @@ export const DashboardBuilderV2 = forwardRef<DashboardBuilderV2Ref, DashboardBui
                           saveDashboard();
                         }
                         if (e.key === 'Escape') {
-                          setDescription(initialData?.description || '');
+                          setDescription(originalDescriptionRef.current);
                           setIsEditingDescription(false);
                         }
                       }}
@@ -2149,7 +2153,7 @@ export const DashboardBuilderV2 = forwardRef<DashboardBuilderV2Ref, DashboardBui
                   ) : (
                     <div
                       className="cursor-pointer hover:bg-gray-50 rounded px-2 py-0.5"
-                      onClick={() => setIsEditingDescription(true)}
+                      onClick={beginEditDescription}
                       data-testid="dashboard-description-display"
                     >
                       {description ? (

--- a/components/dashboard/dashboard-builder-v2.tsx
+++ b/components/dashboard/dashboard-builder-v2.tsx
@@ -493,6 +493,7 @@ export const DashboardBuilderV2 = forwardRef<DashboardBuilderV2Ref, DashboardBui
     const [title, setTitle] = useState(initialData?.title || 'Untitled Dashboard');
     const [description, setDescription] = useState(initialData?.description || '');
     const [isEditingTitle, setIsEditingTitle] = useState(isNewDashboard || false);
+    const [isEditingDescription, setIsEditingDescription] = useState(false);
 
     // Tabs state - initialize from initialData or create default
     const [tabsData, setTabsData] = useState<DashboardTabsData>(() => {
@@ -1769,13 +1770,14 @@ export const DashboardBuilderV2 = forwardRef<DashboardBuilderV2Ref, DashboardBui
                   </Button>
                 )}
 
-                {isEditingTitle ? (
-                  <div className="flex items-center gap-1 flex-1 min-w-0">
+                <div className="flex flex-col gap-0.5 flex-1 min-w-0">
+                  {isEditingTitle ? (
                     <Input
                       value={title}
                       onChange={(e) => setTitle(e.target.value)}
                       placeholder="Dashboard title..."
-                      className="text-sm font-semibold h-8 flex-1"
+                      className="text-sm font-semibold h-8"
+                      data-testid="dashboard-title-input-mobile"
                       autoFocus
                       onKeyDown={(e) => {
                         if (e.key === 'Enter') {
@@ -1792,17 +1794,50 @@ export const DashboardBuilderV2 = forwardRef<DashboardBuilderV2Ref, DashboardBui
                         saveDashboard();
                       }}
                     />
-                  </div>
-                ) : (
-                  <div
-                    className="flex items-center gap-1 flex-1 min-w-0 cursor-pointer"
-                    onClick={() => setIsEditingTitle(true)}
-                  >
-                    <h1 className="text-sm font-semibold truncate flex-1 min-w-0 dashboard-header-title">
-                      {title}
-                    </h1>
-                  </div>
-                )}
+                  ) : (
+                    <div className="cursor-pointer min-w-0" onClick={() => setIsEditingTitle(true)}>
+                      <h1 className="text-sm font-semibold truncate dashboard-header-title">
+                        {title}
+                      </h1>
+                    </div>
+                  )}
+
+                  {isEditingDescription ? (
+                    <Input
+                      value={description}
+                      onChange={(e) => setDescription(e.target.value)}
+                      placeholder="Add description (optional)..."
+                      className="text-xs text-gray-600 h-7"
+                      data-testid="dashboard-description-input-mobile"
+                      autoFocus
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter') {
+                          setIsEditingDescription(false);
+                          saveDashboard();
+                        }
+                        if (e.key === 'Escape') {
+                          setDescription(initialData?.description || '');
+                          setIsEditingDescription(false);
+                        }
+                      }}
+                      onBlur={() => {
+                        setIsEditingDescription(false);
+                        saveDashboard();
+                      }}
+                    />
+                  ) : (
+                    <div
+                      className="cursor-pointer min-w-0"
+                      onClick={() => setIsEditingDescription(true)}
+                    >
+                      {description ? (
+                        <p className="text-xs text-gray-600 truncate">{description}</p>
+                      ) : (
+                        <p className="text-xs text-gray-400 italic">+ Add description</p>
+                      )}
+                    </div>
+                  )}
+                </div>
               </div>
 
               {/* Mobile Quick Actions */}
@@ -2051,14 +2086,15 @@ export const DashboardBuilderV2 = forwardRef<DashboardBuilderV2Ref, DashboardBui
 
                 <div className="h-6 w-px bg-gray-300" />
 
-                {/* Title editing */}
-                {isEditingTitle ? (
-                  <div className="flex items-center gap-2">
+                {/* Title + Description editing */}
+                <div className="flex flex-col gap-0.5 min-w-0">
+                  {isEditingTitle ? (
                     <Input
                       value={title}
                       onChange={(e) => setTitle(e.target.value)}
                       placeholder="Dashboard title..."
-                      className="text-lg font-semibold"
+                      className="text-lg font-semibold h-8"
+                      data-testid="dashboard-title-input"
                       autoFocus
                       onKeyDown={(e) => {
                         if (e.key === 'Enter') {
@@ -2075,15 +2111,55 @@ export const DashboardBuilderV2 = forwardRef<DashboardBuilderV2Ref, DashboardBui
                         saveDashboard();
                       }}
                     />
-                  </div>
-                ) : (
-                  <div
-                    className="flex items-center gap-2 cursor-pointer hover:bg-gray-50 rounded px-2 py-1"
-                    onClick={() => setIsEditingTitle(true)}
-                  >
-                    <h1 className="text-lg font-semibold dashboard-header-title">{title}</h1>
-                  </div>
-                )}
+                  ) : (
+                    <div
+                      className="flex items-center gap-2 cursor-pointer hover:bg-gray-50 rounded px-2 py-0.5"
+                      onClick={() => setIsEditingTitle(true)}
+                      data-testid="dashboard-title-display"
+                    >
+                      <h1 className="text-lg font-semibold dashboard-header-title truncate">
+                        {title}
+                      </h1>
+                    </div>
+                  )}
+
+                  {isEditingDescription ? (
+                    <Input
+                      value={description}
+                      onChange={(e) => setDescription(e.target.value)}
+                      placeholder="Describe what this dashboard shows (optional)..."
+                      className="text-xs text-gray-600 h-7"
+                      data-testid="dashboard-description-input"
+                      autoFocus
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter') {
+                          setIsEditingDescription(false);
+                          saveDashboard();
+                        }
+                        if (e.key === 'Escape') {
+                          setDescription(initialData?.description || '');
+                          setIsEditingDescription(false);
+                        }
+                      }}
+                      onBlur={() => {
+                        setIsEditingDescription(false);
+                        saveDashboard();
+                      }}
+                    />
+                  ) : (
+                    <div
+                      className="cursor-pointer hover:bg-gray-50 rounded px-2 py-0.5"
+                      onClick={() => setIsEditingDescription(true)}
+                      data-testid="dashboard-description-display"
+                    >
+                      {description ? (
+                        <p className="text-xs text-gray-600 truncate max-w-md">{description}</p>
+                      ) : (
+                        <p className="text-xs text-gray-400 italic">+ Add description</p>
+                      )}
+                    </div>
+                  )}
+                </div>
 
                 <div className="h-6 w-px bg-gray-300" />
 
@@ -2102,6 +2178,7 @@ export const DashboardBuilderV2 = forwardRef<DashboardBuilderV2Ref, DashboardBui
                   }}
                   size="sm"
                   variant="outline"
+                  data-testid="add-chart-btn"
                 >
                   <Plus className="w-4 h-4 mr-2" />
                   Add Chart

--- a/components/dashboard/dashboard-builder-v2.tsx
+++ b/components/dashboard/dashboard-builder-v2.tsx
@@ -11,6 +11,8 @@ import { ChartSelectorModal } from './chart-selector-modal';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { Textarea } from '@/components/ui/textarea';
+import { Label } from '@/components/ui/label';
 import { cn } from '@/lib/utils';
 import { apiGet, apiPost, apiPut, apiDelete } from '@/lib/api';
 import {
@@ -74,6 +76,94 @@ import type { DashboardFilter } from '@/hooks/api/useDashboards';
 
 // Grid layout constants - used across GridLayout, SnapIndicators, SpaceMakingIndicators, and animation hooks
 const ROW_HEIGHT = 20;
+
+// Max length for the dashboard description (keeps the header compact).
+const DESCRIPTION_MAX_LENGTH = 100;
+
+/**
+ * Compact description trigger in the header that opens an anchored popover with
+ * a full textarea. Save commits (caller persists via onSave); Escape / outside
+ * click reverts to the pre-edit value.
+ */
+function DashboardDescriptionEditor({
+  value,
+  onChange,
+  onSave,
+  testId,
+}: {
+  value: string;
+  onChange: (next: string) => void;
+  onSave: () => void;
+  testId: string;
+}) {
+  const [open, setOpen] = useState(false);
+  // Snapshot captured when the popover opens, used to revert on dismiss
+  const snapshotRef = useRef(value);
+
+  const handleOpenChange = (next: boolean) => {
+    if (next) {
+      snapshotRef.current = value;
+    } else {
+      // Dismissed without an explicit Save -> revert unsaved edits
+      onChange(snapshotRef.current);
+    }
+    setOpen(next);
+  };
+
+  const handleSave = () => {
+    setOpen(false);
+    onSave();
+  };
+
+  return (
+    <Popover open={open} onOpenChange={handleOpenChange}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          className="text-left rounded px-2 py-0.5 hover:bg-gray-50 max-w-full"
+          data-testid={`${testId}-display`}
+        >
+          {value ? (
+            <span className="block truncate text-xs text-gray-600">{value}</span>
+          ) : (
+            <span className="text-xs text-gray-400 italic">+ Add description</span>
+          )}
+        </button>
+      </PopoverTrigger>
+      <PopoverContent align="start" className="w-80">
+        <div className="flex flex-col gap-2">
+          <Label htmlFor={`${testId}-input`} className="text-sm font-medium">
+            Dashboard description
+          </Label>
+          <Textarea
+            id={`${testId}-input`}
+            value={value}
+            onChange={(e) => onChange(e.target.value)}
+            placeholder="Describe what this dashboard shows (optional)..."
+            className="h-24 resize-none text-sm"
+            maxLength={DESCRIPTION_MAX_LENGTH}
+            autoFocus
+            data-testid={`${testId}-input`}
+            onKeyDown={(e) => {
+              // Cmd/Ctrl+Enter saves; Escape is handled by the Popover (reverts)
+              if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
+                handleSave();
+              }
+            }}
+          />
+          <div className="flex items-center justify-between">
+            <span className="text-xs text-gray-400">
+              {value.length}/{DESCRIPTION_MAX_LENGTH}
+            </span>
+            <Button size="sm" onClick={handleSave} data-testid={`${testId}-save`}>
+              Save
+            </Button>
+          </div>
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}
 
 // Convert DashboardFilter (API response) to DashboardFilterConfig (frontend format)
 function convertFilterToConfig(
@@ -493,14 +583,6 @@ export const DashboardBuilderV2 = forwardRef<DashboardBuilderV2Ref, DashboardBui
     const [title, setTitle] = useState(initialData?.title || 'Untitled Dashboard');
     const [description, setDescription] = useState(initialData?.description || '');
     const [isEditingTitle, setIsEditingTitle] = useState(isNewDashboard || false);
-    const [isEditingDescription, setIsEditingDescription] = useState(false);
-    // Snapshot of description captured when edit mode opens, used to revert on
-    // Escape. Avoids reverting to stale `initialData` after saves.
-    const originalDescriptionRef = useRef(description);
-    const beginEditDescription = useCallback(() => {
-      originalDescriptionRef.current = description;
-      setIsEditingDescription(true);
-    }, [description]);
 
     // Tabs state - initialize from initialData or create default
     const [tabsData, setTabsData] = useState<DashboardTabsData>(() => {
@@ -1809,38 +1891,12 @@ export const DashboardBuilderV2 = forwardRef<DashboardBuilderV2Ref, DashboardBui
                     </div>
                   )}
 
-                  {isEditingDescription ? (
-                    <Input
-                      value={description}
-                      onChange={(e) => setDescription(e.target.value)}
-                      placeholder="Add description (optional)..."
-                      className="text-xs text-gray-600 h-7"
-                      data-testid="dashboard-description-input-mobile"
-                      autoFocus
-                      onKeyDown={(e) => {
-                        if (e.key === 'Enter') {
-                          setIsEditingDescription(false);
-                          saveDashboard();
-                        }
-                        if (e.key === 'Escape') {
-                          setDescription(originalDescriptionRef.current);
-                          setIsEditingDescription(false);
-                        }
-                      }}
-                      onBlur={() => {
-                        setIsEditingDescription(false);
-                        saveDashboard();
-                      }}
-                    />
-                  ) : (
-                    <div className="cursor-pointer min-w-0" onClick={beginEditDescription}>
-                      {description ? (
-                        <p className="text-xs text-gray-600 truncate">{description}</p>
-                      ) : (
-                        <p className="text-xs text-gray-400 italic">+ Add description</p>
-                      )}
-                    </div>
-                  )}
+                  <DashboardDescriptionEditor
+                    value={description}
+                    onChange={setDescription}
+                    onSave={() => saveDashboard()}
+                    testId="dashboard-description-mobile"
+                  />
                 </div>
               </div>
 
@@ -2078,8 +2134,8 @@ export const DashboardBuilderV2 = forwardRef<DashboardBuilderV2Ref, DashboardBui
 
           {/* Desktop Header */}
           <div className="hidden lg:block px-6 py-3">
-            <div className="flex items-center justify-between">
-              <div className="flex items-center gap-3">
+            <div className="flex items-center justify-between gap-4">
+              <div className="flex items-center gap-3 min-w-0">
                 {/* Back button */}
                 {onBack && (
                   <Button variant="ghost" size="sm" onClick={onBack}>
@@ -2090,14 +2146,15 @@ export const DashboardBuilderV2 = forwardRef<DashboardBuilderV2Ref, DashboardBui
 
                 <div className="h-6 w-px bg-gray-300" />
 
-                {/* Title + Description editing */}
-                <div className="flex flex-col gap-0.5 min-w-0">
+                {/* Title + Description editing — fixed width so the toolbar
+                    doesn't shift as the description text grows/shrinks */}
+                <div className="flex flex-col gap-0.5 w-64 flex-shrink-0">
                   {isEditingTitle ? (
                     <Input
                       value={title}
                       onChange={(e) => setTitle(e.target.value)}
                       placeholder="Dashboard title..."
-                      className="text-lg font-semibold h-8"
+                      className="text-lg font-semibold h-8 w-full"
                       data-testid="dashboard-title-input"
                       autoFocus
                       onKeyDown={(e) => {
@@ -2127,46 +2184,19 @@ export const DashboardBuilderV2 = forwardRef<DashboardBuilderV2Ref, DashboardBui
                     </div>
                   )}
 
-                  {isEditingDescription ? (
-                    <Input
-                      value={description}
-                      onChange={(e) => setDescription(e.target.value)}
-                      placeholder="Describe what this dashboard shows (optional)..."
-                      className="text-xs text-gray-600 h-7"
-                      data-testid="dashboard-description-input"
-                      autoFocus
-                      onKeyDown={(e) => {
-                        if (e.key === 'Enter') {
-                          setIsEditingDescription(false);
-                          saveDashboard();
-                        }
-                        if (e.key === 'Escape') {
-                          setDescription(originalDescriptionRef.current);
-                          setIsEditingDescription(false);
-                        }
-                      }}
-                      onBlur={() => {
-                        setIsEditingDescription(false);
-                        saveDashboard();
-                      }}
-                    />
-                  ) : (
-                    <div
-                      className="cursor-pointer hover:bg-gray-50 rounded px-2 py-0.5"
-                      onClick={beginEditDescription}
-                      data-testid="dashboard-description-display"
-                    >
-                      {description ? (
-                        <p className="text-xs text-gray-600 truncate max-w-md">{description}</p>
-                      ) : (
-                        <p className="text-xs text-gray-400 italic">+ Add description</p>
-                      )}
-                    </div>
-                  )}
+                  <DashboardDescriptionEditor
+                    value={description}
+                    onChange={setDescription}
+                    onSave={() => saveDashboard()}
+                    testId="dashboard-description"
+                  />
                 </div>
+              </div>
 
-                <div className="h-6 w-px bg-gray-300" />
+              <div className="h-6 w-px bg-gray-300 flex-shrink-0" />
 
+              {/* Canvas actions — grouped right next to the title */}
+              <div className="flex items-center gap-2 flex-shrink-0">
                 <Button
                   onClick={() => {
                     if (
@@ -2204,7 +2234,8 @@ export const DashboardBuilderV2 = forwardRef<DashboardBuilderV2Ref, DashboardBui
                 </div>
               </div>
 
-              <div className="flex items-center gap-2">
+              {/* Right zone: status + save/preview */}
+              <div className="flex items-center gap-2 flex-1 justify-end">
                 {/* Lock Status */}
                 {isLocked ? (
                   <div className="flex items-center gap-1 text-sm text-green-600">

--- a/components/dashboard/dashboard-native-view.tsx
+++ b/components/dashboard/dashboard-native-view.tsx
@@ -773,6 +773,9 @@ export function DashboardNativeView({
                       </Badge>
                     )}
                   </div>
+                  {dashboard.description && (
+                    <p className="text-xs text-gray-600 mt-1 truncate">{dashboard.description}</p>
+                  )}
                 </div>
               </div>
 
@@ -961,6 +964,13 @@ export function DashboardNativeView({
                     )}
                   </div>
 
+                  {/* Optional description / subtitle */}
+                  {dashboard.description && (
+                    <p className="text-sm text-gray-600 mt-1" data-testid="dashboard-description">
+                      {dashboard.description}
+                    </p>
+                  )}
+
                   {/* Metadata below title */}
                   <div className="flex items-center gap-4 mt-2 text-xs text-gray-500">
                     {dashboard.last_modified_by && (
@@ -1104,6 +1114,9 @@ export function DashboardNativeView({
         <div className="bg-white border-b flex-shrink-0 px-6 py-6">
           <div>
             <h1 className="text-3xl font-bold">{dashboard.title}</h1>
+            {dashboard.description && (
+              <p className="text-base text-gray-600 mt-2">{dashboard.description}</p>
+            )}
           </div>
         </div>
       )}

--- a/components/dashboard/dashboard-native-view.tsx
+++ b/components/dashboard/dashboard-native-view.tsx
@@ -944,32 +944,40 @@ export function DashboardNativeView({
                   </Button>
                 )}
                 <div className="min-w-0 flex-1">
-                  <div className="flex items-center gap-3">
-                    <h1 className="text-2xl font-bold text-gray-900 dashboard-header-title">
+                  <div className="flex items-center gap-3 min-w-0">
+                    <h1 className="text-2xl font-bold text-gray-900 dashboard-header-title truncate min-w-0 flex-shrink-0 max-w-md">
                       {dashboard.title}
                     </h1>
+                    {/* Description shown inline next to the title */}
+                    {dashboard.description && (
+                      <>
+                        <span className="h-5 w-px bg-gray-300 flex-shrink-0" aria-hidden="true" />
+                        <p
+                          className="text-sm text-gray-600 truncate min-w-0"
+                          data-testid="dashboard-description"
+                        >
+                          {dashboard.description}
+                        </p>
+                      </>
+                    )}
                     {dashboard.is_published && (
-                      <Badge variant="default" className="text-xs bg-green-100 text-green-800">
+                      <Badge
+                        variant="default"
+                        className="text-xs bg-green-100 text-green-800 flex-shrink-0"
+                      >
                         Published
                       </Badge>
                     )}
                     {isLocked && (
                       <Badge
                         variant={isLockedByOther ? 'destructive' : 'secondary'}
-                        className="text-xs"
+                        className="text-xs flex-shrink-0"
                       >
                         <Lock className="w-3 h-3 mr-1" />
                         {isLockedByOther ? `Locked by ${lockedBy}` : `Locked by you`}
                       </Badge>
                     )}
                   </div>
-
-                  {/* Optional description / subtitle */}
-                  {dashboard.description && (
-                    <p className="text-sm text-gray-600 mt-1" data-testid="dashboard-description">
-                      {dashboard.description}
-                    </p>
-                  )}
 
                   {/* Metadata below title */}
                   <div className="flex items-center gap-4 mt-2 text-xs text-gray-500">
@@ -1113,9 +1121,11 @@ export function DashboardNativeView({
       {showMinimalHeader && !isEmbedMode && (
         <div className="bg-white border-b flex-shrink-0 px-6 py-6">
           <div>
-            <h1 className="text-3xl font-bold">{dashboard.title}</h1>
+            <h1 className="text-3xl font-bold truncate">{dashboard.title}</h1>
             {dashboard.description && (
-              <p className="text-base text-gray-600 mt-2">{dashboard.description}</p>
+              <p className="text-base text-gray-600 mt-2 line-clamp-2 max-w-3xl">
+                {dashboard.description}
+              </p>
             )}
           </div>
         </div>

--- a/components/dashboard/dashboard-native-view.tsx
+++ b/components/dashboard/dashboard-native-view.tsx
@@ -960,22 +960,11 @@ export function DashboardNativeView({
                   </Button>
                 )}
                 <div className="min-w-0 flex-1">
+                  {/* Title row: title + badges + modified-by/last-updated inline */}
                   <div className="flex items-center gap-3 min-w-0">
-                    <h1 className="text-2xl font-bold text-gray-900 dashboard-header-title truncate min-w-0 flex-shrink-0 max-w-md">
+                    <h1 className="text-2xl font-bold text-gray-900 dashboard-header-title truncate flex-shrink-0 max-w-md">
                       {dashboard.title}
                     </h1>
-                    {/* Description shown inline next to the title */}
-                    {dashboard.description && (
-                      <>
-                        <span className="h-5 w-px bg-gray-300 flex-shrink-0" aria-hidden="true" />
-                        <p
-                          className="text-sm text-gray-600 truncate min-w-0"
-                          data-testid="dashboard-description"
-                        >
-                          {dashboard.description}
-                        </p>
-                      </>
-                    )}
                     {dashboard.is_published && (
                       <Badge
                         variant="default"
@@ -993,18 +982,14 @@ export function DashboardNativeView({
                         {isLockedByOther ? `Locked by ${lockedBy}` : `Locked by you`}
                       </Badge>
                     )}
-                  </div>
-
-                  {/* Metadata below title */}
-                  <div className="flex items-center gap-4 mt-2 text-xs text-gray-500">
                     {dashboard.last_modified_by && (
-                      <div className="flex items-center gap-1">
+                      <div className="flex items-center gap-1 text-xs text-gray-500 flex-shrink-0">
                         <User className="w-3 h-3" />
                         <span>Updated by {dashboard.last_modified_by}</span>
                       </div>
                     )}
                     {dashboard.updated_at && (
-                      <div className="flex items-center gap-1">
+                      <div className="flex items-center gap-1 text-xs text-gray-500 flex-shrink-0">
                         <Clock className="w-3 h-3" />
                         <span>
                           Modified{' '}
@@ -1013,6 +998,16 @@ export function DashboardNativeView({
                       </div>
                     )}
                   </div>
+
+                  {/* Subtitle / description below the title */}
+                  {dashboard.description && (
+                    <p
+                      className="text-sm text-gray-600 mt-1 line-clamp-2 max-w-3xl"
+                      data-testid="dashboard-description"
+                    >
+                      {dashboard.description}
+                    </p>
+                  )}
                 </div>
               </div>
 

--- a/components/dashboard/unified-filters-panel.tsx
+++ b/components/dashboard/unified-filters-panel.tsx
@@ -16,7 +16,9 @@ import {
   PanelLeftClose,
   X,
 } from 'lucide-react';
-import { deleteDashboardFilter } from '@/hooks/api/useDashboards';
+import { deleteDashboardFilter, updateDashboardFilter } from '@/hooks/api/useDashboards';
+import { useSWRConfig } from 'swr';
+import { toastError } from '@/lib/toast';
 import {
   DndContext,
   closestCenter,
@@ -168,6 +170,7 @@ export function UnifiedFiltersPanel({
     getDefaultFilterValues(initialFilters)
   );
   const [isApplyingFilters, setIsApplyingFilters] = useState(false);
+  const { mutate: globalMutate } = useSWRConfig();
   const [isCollapsed, setIsCollapsed] = useState(initiallyCollapsed); // For collapsing entire panel
   const [isFiltersExpanded, setIsFiltersExpanded] = useState(true); // For showing/hiding filter list
   const [locallyDeletedFilterIds, setLocallyDeletedFilterIds] = useState<Set<string>>(new Set()); // Track deleted filters
@@ -260,9 +263,39 @@ export function UnifiedFiltersPanel({
     }
   };
 
-  // Handle filter reordering (internal state only)
-  const handleReorderFilters = (newOrder: DashboardFilterConfig[]) => {
+  // Handle filter reordering — optimistically update local state, then persist
+  // each new `order` value to the backend so the DB-ordered refetch keeps the
+  // user's chosen sequence. Without persistence, the next refetch (Meta.ordering
+  // = ["order"]) would re-emit filters in their old positions and the sync
+  // useEffect above would snap local state back.
+  const handleReorderFilters = async (newOrder: DashboardFilterConfig[]) => {
+    const previousOrder = filters;
     setFilters(newOrder);
+
+    try {
+      // Only PUT filters whose position actually changed
+      const updates = newOrder
+        .map((filter, index) => ({ filter, index }))
+        .filter(({ filter, index }) => {
+          const prevIndex = previousOrder.findIndex((f) => f.id === filter.id);
+          return prevIndex !== index;
+        });
+
+      await Promise.all(
+        updates.map(({ filter, index }) =>
+          updateDashboardFilter(dashboardId, Number(filter.id), { order: index })
+        )
+      );
+
+      // Revalidate the dashboard cache so liveDashboardData.filters reflect
+      // the new order — otherwise the parent's stale initialFilters reference
+      // could re-sync local state on the next render.
+      globalMutate(`/api/dashboards/${dashboardId}/`);
+    } catch (error) {
+      // Revert on failure so UI matches backend
+      setFilters(previousOrder);
+      toastError.update(error, 'filter order');
+    }
   };
 
   // Apply filters - notify parent (this will cause chart re-renders)

--- a/components/dashboard/unified-filters-panel.tsx
+++ b/components/dashboard/unified-filters-panel.tsx
@@ -290,10 +290,11 @@ export function UnifiedFiltersPanel({
       // Revalidate the dashboard cache so liveDashboardData.filters reflect
       // the new order — otherwise the parent's stale initialFilters reference
       // could re-sync local state on the next render.
-      globalMutate(`/api/dashboards/${dashboardId}/`);
+      await globalMutate(`/api/dashboards/${dashboardId}/`);
     } catch (error) {
-      // Revert on failure so UI matches backend
-      setFilters(previousOrder);
+      // Partial writes may already be committed; reload source of truth
+      // instead of guessing at the previous order.
+      await globalMutate(`/api/dashboards/${dashboardId}/`);
       toastError.update(error, 'filter order');
     }
   };

--- a/components/dashboard/unified-filters-panel.tsx
+++ b/components/dashboard/unified-filters-panel.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback, memo } from 'react';
 import { FilterElement } from './filter-element';
 import type { DashboardFilterConfig, AppliedFilters } from '@/types/dashboard-filters';
 import { getDefaultFilterValues } from '@/lib/dashboard-filter-utils';
@@ -57,7 +57,7 @@ interface UnifiedFiltersPanelProps {
 // Unified sortable filter item component
 interface SortableFilterItemProps {
   filter: DashboardFilterConfig;
-  currentFilterValues: Record<string, any>;
+  value: any;
   onFilterChange: (filterId: string, value: any) => void;
   onRemove?: (filterId: string) => void;
   onEdit?: (filter: DashboardFilterConfig) => void;
@@ -68,9 +68,12 @@ interface SortableFilterItemProps {
   isReportMode?: boolean;
 }
 
-function SortableFilterItem({
+// Memoized so unrelated siblings don't re-render when one item's value changes
+// or when dnd-kit fires a dragOver on a neighbor. The default shallow compare
+// works because the parent passes stable refs (useCallback) and per-item value.
+const SortableFilterItem = memo(function SortableFilterItem({
   filter,
-  currentFilterValues,
+  value,
   onFilterChange,
   onRemove,
   onEdit,
@@ -84,27 +87,31 @@ function SortableFilterItem({
     id: filter.id,
   });
 
+  // dnd-kit sets `transition` itself: an empty string for the actively dragged
+  // item (so it follows the pointer 1:1) and a slide-into-place transition for
+  // siblings. Don't add `transition-all` via className — it would animate the
+  // transform of the dragged item and make it lag behind the cursor.
   const style = {
     transform: CSS.Transform.toString(transform),
     transition,
   };
+
+  const handleRemove = useCallback(() => onRemove?.(filter.id), [onRemove, filter.id]);
+  const handleEdit = useCallback(() => onEdit?.(filter), [onEdit, filter]);
 
   if (layout === 'horizontal') {
     return (
       <div
         ref={setNodeRef}
         style={style}
-        className={cn(
-          'min-w-[250px] max-w-[400px] flex-shrink-0 transition-all',
-          isDragging && 'shadow-lg scale-105 z-50'
-        )}
+        className={cn('min-w-[250px] max-w-[400px] flex-shrink-0', isDragging && 'shadow-lg z-50')}
       >
         <FilterElement
           filter={filter}
-          value={currentFilterValues[filter.id] ?? null}
+          value={value}
           onChange={onFilterChange}
-          onRemove={isEditMode ? () => onRemove?.(filter.id) : undefined}
-          onEdit={isEditMode ? () => onEdit?.(filter) : undefined}
+          onRemove={isEditMode ? handleRemove : undefined}
+          onEdit={isEditMode ? handleEdit : undefined}
           isPublicMode={isPublicMode}
           publicToken={publicToken}
           isReportMode={isReportMode}
@@ -123,18 +130,18 @@ function SortableFilterItem({
       ref={setNodeRef}
       style={style}
       className={cn(
-        'border border-gray-100 rounded-lg p-3 bg-gray-50 transition-all',
-        isDragging && 'shadow-lg scale-105 z-50',
+        'border border-gray-100 rounded-lg p-3 bg-gray-50',
+        isDragging && 'shadow-lg z-50',
         isEditMode && 'hover:border-gray-300'
       )}
       {...attributes}
     >
       <FilterElement
         filter={filter}
-        value={currentFilterValues[filter.id] ?? null}
+        value={value}
         onChange={onFilterChange}
-        onRemove={isEditMode ? () => onRemove?.(filter.id) : undefined}
-        onEdit={isEditMode ? () => onEdit?.(filter) : undefined}
+        onRemove={isEditMode ? handleRemove : undefined}
+        onEdit={isEditMode ? handleEdit : undefined}
         isEditMode={isEditMode}
         showTitle={true}
         compact={false}
@@ -145,7 +152,7 @@ function SortableFilterItem({
       />
     </div>
   );
-}
+});
 
 export function UnifiedFiltersPanel({
   initialFilters,
@@ -234,70 +241,74 @@ export function UnifiedFiltersPanel({
   }, [initialFilters, getDefaultFilterValues, locallyDeletedFilterIds]);
 
   // Handle filter value changes (internal only - no parent re-render)
-  const handleFilterChange = (filterId: string, value: any) => {
-    setCurrentFilterValues((prev) => {
-      const updated = {
-        ...prev,
-        [filterId]: value,
-      };
-      return updated;
-    });
-  };
+  // Stable ref so memoized SortableFilterItem doesn't re-render unnecessarily.
+  const handleFilterChange = useCallback((filterId: string, value: any) => {
+    setCurrentFilterValues((prev) => ({
+      ...prev,
+      [filterId]: value,
+    }));
+  }, []);
 
   // Handle filter removal (internal state management)
-  const handleRemoveFilter = async (filterId: string) => {
-    try {
-      await deleteDashboardFilter(dashboardId, parseInt(filterId));
+  const handleRemoveFilter = useCallback(
+    async (filterId: string) => {
+      try {
+        await deleteDashboardFilter(dashboardId, parseInt(filterId));
 
-      // Track this filter as locally deleted to prevent it from reappearing
-      setLocallyDeletedFilterIds((prev) => new Set(prev).add(String(filterId)));
+        // Track this filter as locally deleted to prevent it from reappearing
+        setLocallyDeletedFilterIds((prev) => new Set(prev).add(String(filterId)));
 
-      setFilters((prev) => prev.filter((filter) => filter.id !== filterId));
-      setCurrentFilterValues((prev) => {
-        const updated = { ...prev };
-        delete updated[filterId];
-        return updated;
-      });
-    } catch (error: any) {
-      console.error('Failed to delete filter:', error.message || 'Please try again');
-    }
-  };
+        setFilters((prev) => prev.filter((filter) => filter.id !== filterId));
+        setCurrentFilterValues((prev) => {
+          const updated = { ...prev };
+          delete updated[filterId];
+          return updated;
+        });
+      } catch (error: any) {
+        console.error('Failed to delete filter:', error.message || 'Please try again');
+      }
+    },
+    [dashboardId]
+  );
 
   // Handle filter reordering — optimistically update local state, then persist
   // each new `order` value to the backend so the DB-ordered refetch keeps the
   // user's chosen sequence. Without persistence, the next refetch (Meta.ordering
   // = ["order"]) would re-emit filters in their old positions and the sync
   // useEffect above would snap local state back.
-  const handleReorderFilters = async (newOrder: DashboardFilterConfig[]) => {
-    const previousOrder = filters;
-    setFilters(newOrder);
+  const handleReorderFilters = useCallback(
+    async (newOrder: DashboardFilterConfig[]) => {
+      const previousOrder = filters;
+      setFilters(newOrder);
 
-    try {
-      // Only PUT filters whose position actually changed
-      const updates = newOrder
-        .map((filter, index) => ({ filter, index }))
-        .filter(({ filter, index }) => {
-          const prevIndex = previousOrder.findIndex((f) => f.id === filter.id);
-          return prevIndex !== index;
-        });
+      try {
+        // Only PUT filters whose position actually changed
+        const updates = newOrder
+          .map((filter, index) => ({ filter, index }))
+          .filter(({ filter, index }) => {
+            const prevIndex = previousOrder.findIndex((f) => f.id === filter.id);
+            return prevIndex !== index;
+          });
 
-      await Promise.all(
-        updates.map(({ filter, index }) =>
-          updateDashboardFilter(dashboardId, Number(filter.id), { order: index })
-        )
-      );
+        await Promise.all(
+          updates.map(({ filter, index }) =>
+            updateDashboardFilter(dashboardId, Number(filter.id), { order: index })
+          )
+        );
 
-      // Revalidate the dashboard cache so liveDashboardData.filters reflect
-      // the new order — otherwise the parent's stale initialFilters reference
-      // could re-sync local state on the next render.
-      await globalMutate(`/api/dashboards/${dashboardId}/`);
-    } catch (error) {
-      // Partial writes may already be committed; reload source of truth
-      // instead of guessing at the previous order.
-      await globalMutate(`/api/dashboards/${dashboardId}/`);
-      toastError.update(error, 'filter order');
-    }
-  };
+        // Revalidate the dashboard cache so liveDashboardData.filters reflect
+        // the new order — otherwise the parent's stale initialFilters reference
+        // could re-sync local state on the next render.
+        await globalMutate(`/api/dashboards/${dashboardId}/`);
+      } catch (error) {
+        // Partial writes may already be committed; reload source of truth
+        // instead of guessing at the previous order.
+        await globalMutate(`/api/dashboards/${dashboardId}/`);
+        toastError.update(error, 'filter order');
+      }
+    },
+    [filters, dashboardId, globalMutate]
+  );
 
   // Apply filters - notify parent (this will cause chart re-renders)
   const handleApplyFilters = async () => {
@@ -336,23 +347,29 @@ export function UnifiedFiltersPanel({
     }
   };
 
+  // 5px activation distance lets clicks on the drag handle pass through to
+  // child buttons without starting a phantom drag, and removes the small
+  // "stickiness" at the start of a real drag.
   const sensors = useSensors(
-    useSensor(PointerSensor),
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
     useSensor(KeyboardSensor, {
       coordinateGetter: sortableKeyboardCoordinates,
     })
   );
 
-  const handleDragEnd = (event: DragEndEvent) => {
-    const { active, over } = event;
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      const { active, over } = event;
 
-    if (over && active.id !== over.id) {
-      const oldIndex = filters.findIndex((filter) => filter.id === active.id);
-      const newIndex = filters.findIndex((filter) => filter.id === over.id);
-      const newOrder = arrayMove(filters, oldIndex, newIndex);
-      handleReorderFilters(newOrder);
-    }
-  };
+      if (over && active.id !== over.id) {
+        const oldIndex = filters.findIndex((filter) => filter.id === active.id);
+        const newIndex = filters.findIndex((filter) => filter.id === over.id);
+        const newOrder = arrayMove(filters, oldIndex, newIndex);
+        handleReorderFilters(newOrder);
+      }
+    },
+    [filters]
+  );
 
   // Check if any filters have values
   // In report mode, locked filters are auto-set from the frozen report config and cannot
@@ -580,7 +597,7 @@ export function UnifiedFiltersPanel({
                         <SortableFilterItem
                           key={filter.id}
                           filter={filter}
-                          currentFilterValues={currentFilterValues}
+                          value={currentFilterValues[filter.id] ?? null}
                           onFilterChange={handleFilterChange}
                           onRemove={handleRemoveFilter}
                           onEdit={onEditFilter}
@@ -718,7 +735,7 @@ export function UnifiedFiltersPanel({
                         <SortableFilterItem
                           key={filter.id}
                           filter={filter}
-                          currentFilterValues={currentFilterValues}
+                          value={currentFilterValues[filter.id] ?? null}
                           onFilterChange={handleFilterChange}
                           onRemove={handleRemoveFilter}
                           onEdit={onEditFilter}

--- a/components/dashboard/unified-filters-panel.tsx
+++ b/components/dashboard/unified-filters-panel.tsx
@@ -271,18 +271,14 @@ export function UnifiedFiltersPanel({
     [dashboardId]
   );
 
-  // Handle filter reordering — optimistically update local state, then persist
-  // each new `order` value to the backend so the DB-ordered refetch keeps the
-  // user's chosen sequence. Without persistence, the next refetch (Meta.ordering
-  // = ["order"]) would re-emit filters in their old positions and the sync
-  // useEffect above would snap local state back.
+  // Persist new order to backend — without this, the next refetch
+  // (DB ordered by `order`) snaps filters back to their old positions.
   const handleReorderFilters = useCallback(
     async (newOrder: DashboardFilterConfig[]) => {
       const previousOrder = filters;
       setFilters(newOrder);
 
       try {
-        // Only PUT filters whose position actually changed
         const updates = newOrder
           .map((filter, index) => ({ filter, index }))
           .filter(({ filter, index }) => {
@@ -296,13 +292,9 @@ export function UnifiedFiltersPanel({
           )
         );
 
-        // Revalidate the dashboard cache so liveDashboardData.filters reflect
-        // the new order — otherwise the parent's stale initialFilters reference
-        // could re-sync local state on the next render.
         await globalMutate(`/api/dashboards/${dashboardId}/`);
       } catch (error) {
-        // Partial writes may already be committed; reload source of truth
-        // instead of guessing at the previous order.
+        // Partial writes may have committed — reload source of truth.
         await globalMutate(`/api/dashboards/${dashboardId}/`);
         toastError.update(error, 'filter order');
       }

--- a/hooks/api/useDashboards.ts
+++ b/hooks/api/useDashboards.ts
@@ -8,6 +8,7 @@ export type DashboardTabData = DashboardTab;
 export interface Dashboard {
   id: number;
   title: string;
+  description?: string;
   dashboard_type: 'native' | 'superset';
   grid_columns: number;
   target_screen_size?: 'desktop' | 'tablet' | 'mobile' | 'a4'; // Target screen size for design


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dashboard description editor popover with truncated trigger, max-length textarea, char counter, Save and Cmd/Ctrl+Enter support.

* **Improvements**
  * Dashboard descriptions shown as subtitles in mobile, desktop, and minimal headers when present.
  * Filter list rendering and drag-reorder stabilized; reordering now persists optimistically.
  * CSV export no longer duplicates dashboard filters in payload and passes filters via the export query when needed.

* **Chores**
  * Ignore added Playwright artifact and an image file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->