### PR TITLE
fix(warehouse): UI not updating after creation due to invalid respons…

### DIFF
--- a/hooks/api/useWarehouse.ts
+++ b/hooks/api/useWarehouse.ts
@@ -113,9 +113,8 @@ export async function createWarehouse(payload: {
   name: string;
   destinationDefId: string;
   airbyteConfig: Record<string, unknown>;
-}): Promise<Warehouse> {
-  const raw: WarehouseApiItem = await apiPost('/api/organizations/warehouse/', payload);
-  return mapWarehouseResponse(raw);
+}): Promise<void> {
+  await apiPost('/api/organizations/warehouse/', payload);
 }
 
 export async function updateWarehouse(


### PR DESCRIPTION
Root Cause
When the warehouse was saved, the backend responded with a simple success confirmation. The frontend was trying to read warehouse details from that confirmation (which didn't have any), causing a hidden error. Because of this error, the page never knew the warehouse was created and didn't refresh itself.

Fix
The frontend now simply acknowledges the success confirmation and then fetches the latest warehouse data from the server — which correctly shows the newly created warehouse.

Changes
hooks/api/useWarehouse.ts — fixed the warehouse creation function to not read data from the save confirmation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Warehouse creation now simplifies API response handling: the client no longer returns created warehouse details after submission, reducing payload processing and streamlining the request flow. This is an internal change and should not alter visible behavior, but it makes warehouse creation handling leaner and more predictable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->