### PR TITLE
fix(analytics): migrate old email identities to user_id; add current …

### DIFF
--- a/lib/__tests__/analytics.test.ts
+++ b/lib/__tests__/analytics.test.ts
@@ -5,6 +5,8 @@ const mockIdentify = jest.fn();
 const mockGroup = jest.fn();
 const mockReset = jest.fn();
 const mockRegister = jest.fn();
+const mockSetPersonProperties = jest.fn();
+const mockGetDistinctId = jest.fn();
 
 jest.mock('posthog-js', () => ({
   __esModule: true,
@@ -14,6 +16,8 @@ jest.mock('posthog-js', () => ({
     group: (...args: unknown[]) => mockGroup(...args),
     reset: (...args: unknown[]) => mockReset(...args),
     register: (...args: unknown[]) => mockRegister(...args),
+    setPersonProperties: (...args: unknown[]) => mockSetPersonProperties(...args),
+    get_distinct_id: (...args: unknown[]) => mockGetDistinctId(...args),
   },
 }));
 
@@ -66,12 +70,30 @@ describe('trackFeatureView', () => {
 });
 
 describe('identifyUser', () => {
-  it('identifies by user_id (string), sends is_internal, registers role, never sends email', () => {
+  it('identifies by user_id, sets is_internal + current_role, registers role, never sends email', () => {
+    mockGetDistinctId.mockReturnValue('42');
     identifyUser(42, 'staff@dalgo.org', { role: 'account-manager' });
-    expect(mockIdentify).toHaveBeenCalledWith('42', { is_internal: true });
+    expect(mockIdentify).toHaveBeenCalledWith('42', {
+      is_internal: true,
+      current_role: 'account-manager',
+    });
     expect(mockRegister).toHaveBeenCalledWith({ role: 'account-manager' });
     const identifyArgs = mockIdentify.mock.calls[0];
     expect(JSON.stringify(identifyArgs)).not.toContain('staff@dalgo.org');
+  });
+  it('resets first when the current distinct_id is an old email identity, then identifies by id', () => {
+    mockGetDistinctId.mockReturnValue('jake@agency.fund');
+    identifyUser(101, 'jake@agency.fund', { role: 'viewer' });
+    expect(mockReset).toHaveBeenCalled();
+    expect(mockIdentify).toHaveBeenCalledWith('101', {
+      is_internal: false,
+      current_role: 'viewer',
+    });
+  });
+  it('does NOT reset when already identified by a numeric id', () => {
+    mockGetDistinctId.mockReturnValue('60');
+    identifyUser(60, 'user@ngo.example', { role: 'admin' });
+    expect(mockReset).not.toHaveBeenCalled();
   });
   it('no-ops when userId is falsy (backend not yet deployed)', () => {
     identifyUser(0, 'staff@dalgo.org', { role: 'admin' });
@@ -80,12 +102,17 @@ describe('identifyUser', () => {
 });
 
 describe('identifyOrg', () => {
-  it('calls posthog.group for the organization group type with enriched props', () => {
+  it('groups by organization and sets current_org_* person properties', () => {
     identifyOrg('ngo-slug', { name: 'NGO Name', plan: 'Free Trial' });
     expect(mockGroup).toHaveBeenCalledWith('organization', 'ngo-slug', {
       name: 'NGO Name',
       slug: 'ngo-slug',
       subscription_plan: 'Free Trial',
+    });
+    expect(mockSetPersonProperties).toHaveBeenCalledWith({
+      current_org_slug: 'ngo-slug',
+      current_org_name: 'NGO Name',
+      current_subscription_plan: 'Free Trial',
     });
   });
 });

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -24,19 +24,33 @@ export function trackFeatureView(feature: Feature, opts?: { tab?: string }): voi
 }
 
 // Identify by the Django auth_user PK (non-PII, stable per human). Email is
-// NEVER sent — is_internal is derived locally from the email domain. role is
-// org-specific, so it is registered as a super property (rides every event and
-// refreshes on org switch). No-ops if userId is falsy (e.g. backend not yet
-// deployed with user_id), so analytics degrades gracefully instead of breaking.
+// NEVER sent — is_internal is derived locally from the email domain.
+// role is sent two ways: as a super property (rides EVERY event, so it stays
+// accurate per-event even when a multi-org user switches orgs) AND as a
+// current_role person property (latest value, for visibility on the profile).
+// No-ops if userId is falsy (e.g. backend not yet deployed with user_id), so
+// analytics degrades gracefully instead of breaking.
 export function identifyUser(userId: number, email: string, { role }: { role?: string }): void {
   if (!userId) return;
-  posthog.identify(String(userId), { is_internal: isInternalEmail(email) });
+  // Migrate users still on the old email-based identity (from a previous build)
+  // onto user_id. posthog.identify() won't override an already-identified
+  // distinct_id, so we reset first when the current id looks like an email.
+  const current = posthog.get_distinct_id?.();
+  if (current && current.includes('@')) {
+    posthog.reset();
+  }
+  posthog.identify(String(userId), {
+    is_internal: isInternalEmail(email),
+    current_role: role,
+  });
   posthog.register({ role });
 }
 
 // Organization group — the multi-tenant analysis lens (per-NGO). subscription_plan
 // (Free Trial | Dalgo | Internal) is the segmentation dimension; it subsumes the
 // old is_demo boolean, which the data model never actually sets.
+// The group keeps per-event org (correct for multi-org users); current_org_* are
+// person properties for profile visibility and show only the user's latest org.
 export function identifyOrg(
   slug: string,
   { name, plan }: { name: string; plan?: string | null }
@@ -45,6 +59,11 @@ export function identifyOrg(
     name,
     slug,
     subscription_plan: plan ?? null,
+  });
+  posthog.setPersonProperties({
+    current_org_slug: slug,
+    current_org_name: name,
+    current_subscription_plan: plan ?? null,
   });
 }
 


### PR DESCRIPTION
…org/role person props

1. identifyUser resets first when the current distinct_id looks like an email (old email-based identity from a previous build), so those users switch to user_id instead of staying stuck on email.
2. Set current_role + current_org_slug/name/plan as person properties for profile visibility (latest values — accurate for single-org users; shows the most recent org for multi-org users). The role super-property and organization group are unchanged and remain the per-event source of truth.

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/DalgoT4D/webapp) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Please ensure coding standard and conventions are followed.

-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for analytics functions with validation of user identification flows, organization tracking, attribute persistence, and identity migration/reset handling.

* **Chores**
  * Improved user identification to support seamless identity type transitions and proper reset handling in migration scenarios.
  * Enhanced organization profile tracking to capture additional organization attributes, names, and subscription plan metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->