### PR TITLE
fix: dashboard tab tooltip and chart editor DATA tab scroll

### DIFF
--- a/app/charts/[id]/edit/page.tsx
+++ b/app/charts/[id]/edit/page.tsx
@@ -1738,8 +1738,8 @@ function EditChartPageContent() {
                 </div>
               </TabsContent>
 
-              <TabsContent value="data" className="h-[calc(100%-73px)] overflow-y-auto">
-                <div className="p-4">
+              <TabsContent value="data" className="h-[calc(100%-73px)] overflow-hidden">
+                <div className="p-4 h-full">
                   <Tabs
                     defaultValue={
                       formData.chart_type === ChartTypes.TABLE ? 'raw-data' : 'chart-data'

--- a/components/dashboard/tabs/TabBar.tsx
+++ b/components/dashboard/tabs/TabBar.tsx
@@ -4,6 +4,7 @@ import { useState, useCallback, useRef, useEffect, memo, useMemo } from 'react';
 import { Plus, X } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { cn } from '@/lib/utils';
 import { DashboardTab } from '@/types/dashboard';
 import { TAB_TITLE_MAX_LENGTH, createNewTab, getNextTabNumber } from './tab-utils';
@@ -152,22 +153,26 @@ const TabItem = memo(function TabItem({
           onClick={(e) => e.stopPropagation()}
         />
       ) : (
-        <button
-          type="button"
-          className={cn(
-            'truncate max-w-32 text-sm bg-transparent border-none p-0',
-            isEditMode && isActive && !isOnlyTab
-              ? 'cursor-pointer hover:underline'
-              : 'cursor-default pointer-events-none'
-          )}
-          title={tab.title}
-          data-testid={`tab-title-${tab.id}`}
-          onClick={handleTitleClick}
-          aria-label={`Rename ${tab.title} tab`}
-          tabIndex={isEditMode && isActive && !isOnlyTab ? 0 : -1}
-        >
-          {tab.title}
-        </button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              className={cn(
+                'truncate max-w-32 text-sm bg-transparent border-none p-0',
+                isEditMode && isActive && !isOnlyTab
+                  ? 'cursor-pointer hover:underline'
+                  : 'cursor-default'
+              )}
+              data-testid={`tab-title-${tab.id}`}
+              onClick={handleTitleClick}
+              aria-label={`Rename ${tab.title} tab`}
+              tabIndex={isEditMode && isActive && !isOnlyTab ? 0 : -1}
+            >
+              {tab.title}
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">{tab.title}</TooltipContent>
+        </Tooltip>
       )}
 
       {/* Remove button - only show in edit mode and when more than 1 tab */}


### PR DESCRIPTION
DALGO-1347: show full tab title on hover in both view and edit mode
DALGO-1376: prevent DATA tab from auto-scrolling when data loads

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced tooltip display for tab titles using dedicated UI components for improved information visibility
  * Optimized data tab container layout for improved content presentation and overflow handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->