### PR TITLE
Number formatting in kpis & its effect on KPIs, Alerts

### DIFF
--- a/__tests__/lib/formatters.test.ts
+++ b/__tests__/lib/formatters.test.ts
@@ -13,8 +13,7 @@ describe('formatNumber', () => {
     [1000000, 'international', '1,000,000'],
     [1000000, 'indian', '10,00,000'],
     [1000000, 'european', '1.000.000'],
-    [85.5, 'percentage', '85.5%'],
-    [1000, 'currency', '$1,000'],
+    [0.855, 'percentage', '85.5%'],
     [-1234567, 'international', '-1,234,567'],
     [0, 'international', '0'],
     [0, 'indian', '0'],
@@ -27,7 +26,7 @@ describe('formatNumber', () => {
     [1234567, { format: 'international', decimalPlaces: 2 }, '1,234,567.00'],
     [1234567, { format: 'indian', decimalPlaces: 2 }, '12,34,567.00'],
     [1234567, { format: 'european', decimalPlaces: 2 }, '1.234.567,00'],
-    [85.567, { format: 'percentage', decimalPlaces: 1 }, '85.6%'],
+    [0.85567, { format: 'percentage', decimalPlaces: 1 }, '85.6%'],
     [0.005, { format: 'default', decimalPlaces: 2 }, '0.01'],
     [0, { format: 'international', decimalPlaces: 2 }, '0.00'],
   ])('formatNumber(%s, %j) => %s (with decimal places)', (value, options, expected) => {
@@ -91,7 +90,7 @@ describe('formatKPIValue', () => {
 
   it.each([
     [123456, { numberFormat: 'indian', decimalPlaces: 0, numberPrefix: '₹' }, '₹1,23,456'],
-    [85, { numberFormat: 'percentage', decimalPlaces: 0 }, '85%'],
+    [0.85, { numberFormat: 'percentage', decimalPlaces: 0 }, '85%'],
     [
       1500,
       { numberFormat: 'default', decimalPlaces: 0, numberPrefix: '', numberSuffix: ' people' },

--- a/__tests__/lib/formatters.test.ts
+++ b/__tests__/lib/formatters.test.ts
@@ -2,7 +2,7 @@
  * Tests for formatters utility
  */
 
-import { formatNumber, formatDate, type DateFormat } from '@/lib/formatters';
+import { formatNumber, formatDate, formatKPIValue, type DateFormat } from '@/lib/formatters';
 
 describe('formatNumber', () => {
   it.each([
@@ -68,6 +68,42 @@ describe('formatNumber', () => {
     [150000000, { format: 'adaptive_indian', decimalPlaces: 0 }, '15Cr'],
   ])('formatNumber(%s, %j) => %s (adaptive with decimal places)', (value, options, expected) => {
     expect(formatNumber(value as number, options as any)).toBe(expected);
+  });
+});
+
+describe('formatKPIValue', () => {
+  it('returns "No data" for null/undefined/NaN — no prefix/suffix wrap', () => {
+    expect(formatKPIValue(null, { numberPrefix: '₹', numberSuffix: '%' })).toBe('No data');
+    expect(formatKPIValue(undefined, { numberFormat: 'indian' })).toBe('No data');
+    expect(formatKPIValue(NaN, { numberPrefix: '$' })).toBe('No data');
+  });
+
+  it('shows the raw number as-is when no customizations are set', () => {
+    // No grouping, no compression — pure String(value)
+    expect(formatKPIValue(1_234_567)).toBe('1234567');
+    expect(formatKPIValue(85.5)).toBe('85.5');
+  });
+
+  it('shows raw number when customizations object has no numberFormat', () => {
+    // Edge: prefix/suffix without format → still no formatting applied
+    expect(formatKPIValue(1500, { numberPrefix: '₹' })).toBe('1500');
+  });
+
+  it.each([
+    [123456, { numberFormat: 'indian', decimalPlaces: 0, numberPrefix: '₹' }, '₹1,23,456'],
+    [85, { numberFormat: 'percentage', decimalPlaces: 0 }, '85%'],
+    [
+      1500,
+      { numberFormat: 'default', decimalPlaces: 0, numberPrefix: '', numberSuffix: ' people' },
+      '1500 people',
+    ],
+    [
+      2_500_000,
+      { numberFormat: 'adaptive_international', decimalPlaces: 2, numberPrefix: '$' },
+      '$2.50M',
+    ],
+  ])('formatKPIValue(%s, %j) => %s', (value, customizations, expected) => {
+    expect(formatKPIValue(value as number, customizations as any)).toBe(expected);
   });
 });
 

--- a/components/charts/types/__tests__/NumberFormatSection.test.tsx
+++ b/components/charts/types/__tests__/NumberFormatSection.test.tsx
@@ -151,21 +151,4 @@ describe('NumberFormatSection', () => {
     // Should default to 0 when empty
     expect(mockOnDecimalPlacesChange).toHaveBeenCalledWith(0);
   });
-
-  it('should exclude specified formats when excludeFormats is provided', async () => {
-    const user = userEvent.setup();
-    render(<NumberFormatSection {...defaultProps} excludeFormats={['percentage', 'currency']} />);
-
-    await user.click(screen.getByLabelText('Number Format'));
-
-    // These should be present
-    expect(screen.getByRole('option', { name: 'No Formatting' })).toBeInTheDocument();
-    expect(
-      screen.getByRole('option', { name: 'Indian (1234567 => 12,34,567)' })
-    ).toBeInTheDocument();
-
-    // These should NOT be present
-    expect(screen.queryByRole('option', { name: 'Percentage (%)' })).not.toBeInTheDocument();
-    expect(screen.queryByRole('option', { name: 'Currency ($)' })).not.toBeInTheDocument();
-  });
 });

--- a/components/charts/types/__tests__/TableChartCustomizations.test.tsx
+++ b/components/charts/types/__tests__/TableChartCustomizations.test.tsx
@@ -186,26 +186,8 @@ describe('TableChartCustomizations', () => {
     expect(removeButton).toBeDisabled();
   });
 
-  // Note: Detailed number formatting behavior (clamping, excludeFormats, etc.)
-  // is tested in NumberFormatSection.test.tsx. These tests verify integration only.
-
-  it('should exclude percentage and currency formats', async () => {
-    const user = userEvent.setup();
-    render(<TableChartCustomizations {...defaultProps} />);
-
-    await user.click(screen.getByTestId('column-row-budget'));
-    await user.click(screen.getByLabelText('Number Format'));
-
-    // These should be present
-    expect(screen.getByRole('option', { name: 'No Formatting' })).toBeInTheDocument();
-    expect(
-      screen.getByRole('option', { name: 'Indian (1234567 => 12,34,567)' })
-    ).toBeInTheDocument();
-
-    // These should NOT be present (excluded for table charts)
-    expect(screen.queryByRole('option', { name: 'Percentage (%)' })).not.toBeInTheDocument();
-    expect(screen.queryByRole('option', { name: 'Currency ($)' })).not.toBeInTheDocument();
-  });
+  // Note: Detailed number formatting behavior (clamping etc.) is tested in
+  // NumberFormatSection.test.tsx. These tests verify integration only.
 
   it('should render new enhancement sections', () => {
     render(<TableChartCustomizations {...defaultProps} />);

--- a/components/charts/types/shared/NumberFormatSection.tsx
+++ b/components/charts/types/shared/NumberFormatSection.tsx
@@ -25,16 +25,8 @@ export const NUMBER_FORMAT_OPTIONS = [
   { value: NumberFormats.INDIAN, label: 'Indian (1234567 => 12,34,567)' },
   { value: NumberFormats.INTERNATIONAL, label: 'International (1234567 => 1,234,567)' },
   { value: NumberFormats.EUROPEAN, label: 'European (1234567 => 1.234.567)' },
-  { value: NumberFormats.PERCENTAGE, label: 'Percentage (%)' },
-  { value: NumberFormats.CURRENCY, label: 'Currency ($)' },
+  { value: NumberFormats.PERCENTAGE, label: 'Percentage (0.85 => 85.00%)' },
 ] as const;
-
-/**
- * Format options for table charts (excludes percentage and currency)
- */
-export const TABLE_NUMBER_FORMAT_OPTIONS = NUMBER_FORMAT_OPTIONS.filter(
-  (opt) => opt.value !== NumberFormats.PERCENTAGE && opt.value !== NumberFormats.CURRENCY
-);
 
 interface NumberFormatSectionProps {
   /**
@@ -70,15 +62,11 @@ interface NumberFormatSectionProps {
    * Custom description text (only shown if showDescription is true)
    */
   description?: string;
-  /**
-   * Format values to exclude from the dropdown (e.g., ['percentage', 'currency'] for table charts)
-   */
-  excludeFormats?: string[];
 }
 
 /**
  * Reusable component for number format dropdown and decimal places input.
- * Used by Line, Bar, Pie,Table and Number chart customization panels.
+ * Used by Line, Bar, Pie, Table, Number chart customization panels and the KPI form.
  */
 export function NumberFormatSection({
   idPrefix,
@@ -89,17 +77,11 @@ export function NumberFormatSection({
   disabled = false,
   showDescription = false,
   description = 'Applied to axis labels, data labels, and tooltips',
-  excludeFormats = [],
 }: NumberFormatSectionProps) {
   const handleDecimalChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = Math.min(MAX_DECIMAL_PLACES, Math.max(0, parseInt(e.target.value) || 0));
     onDecimalPlacesChange(value);
   };
-
-  // Filter out excluded formats
-  const availableOptions = NUMBER_FORMAT_OPTIONS.filter(
-    (opt) => !excludeFormats.includes(opt.value)
-  );
 
   return (
     <>
@@ -114,7 +96,7 @@ export function NumberFormatSection({
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
-            {availableOptions.map((opt) => (
+            {NUMBER_FORMAT_OPTIONS.map((opt) => (
               <SelectItem key={opt.value} value={opt.value}>
                 {opt.label}
               </SelectItem>

--- a/components/charts/types/table/TableChartCustomizations.tsx
+++ b/components/charts/types/table/TableChartCustomizations.tsx
@@ -5,7 +5,7 @@ import { Button } from '@/components/ui/button';
 import { Switch } from '@/components/ui/switch';
 import { Label } from '@/components/ui/label';
 import { Trash2, ChevronRight, ChevronDown } from 'lucide-react';
-import { NumberFormats, type NumberFormat, type DateFormat } from '@/lib/formatters';
+import { type NumberFormat, type DateFormat } from '@/lib/formatters';
 import { NumberFormatSection, NUMBER_FORMAT_OPTIONS } from '../shared/NumberFormatSection';
 import { DateFormatSection, DATE_FORMAT_OPTIONS } from '../shared/DateFormatSection';
 import { ConditionalFormattingSection } from './ConditionalFormattingSection';
@@ -284,7 +284,6 @@ export function TableChartCustomizations({
                         decimalPlaces={config?.decimalPlaces}
                         onNumberFormatChange={(value) => handleFormatChange(column, value)}
                         onDecimalPlacesChange={(value) => handleDecimalChange(column, value)}
-                        excludeFormats={[NumberFormats.PERCENTAGE, NumberFormats.CURRENCY]}
                         disabled={disabled}
                       />
                     </div>

--- a/components/dashboard/kpi-chart-element.tsx
+++ b/components/dashboard/kpi-chart-element.tsx
@@ -58,6 +58,7 @@ export function KPIChartElement({
     updatedAt: config?.updated_at || new Date().toISOString(),
     isLoading,
     periods,
+    customizations: chartData?.customizations ?? undefined,
   };
 
   const commentButton = snapshotId ? (

--- a/components/kpis/kpi-card.tsx
+++ b/components/kpis/kpi-card.tsx
@@ -24,9 +24,11 @@ import { formatDistanceToNow, format as formatDate, parseISO, isValid } from 'da
 function EChartsRenderer({
   config,
   height = 'h-32',
+  customizations,
 }: {
   config: Record<string, any>;
   height?: string;
+  customizations?: KPICustomizations;
 }) {
   const chartRef = useRef<HTMLDivElement>(null);
   const chartInstance = useRef<echarts.ECharts | null>(null);
@@ -38,7 +40,20 @@ function EChartsRenderer({
       chartInstance.current.dispose();
     }
     chartInstance.current = echarts.init(chartRef.current);
-    chartInstance.current.setOption(config);
+
+    // Inject a tooltip valueFormatter so trendline hover values render with
+    // the KPI's customizations (matches the card's current value + target).
+    const effectiveConfig = customizations
+      ? {
+          ...config,
+          tooltip: {
+            ...(config.tooltip || {}),
+            valueFormatter: (value: number | null) => formatKPIValue(value, customizations),
+          },
+        }
+      : config;
+
+    chartInstance.current.setOption(effectiveConfig);
 
     const handleResize = () => chartInstance.current?.resize();
     window.addEventListener('resize', handleResize);
@@ -53,7 +68,7 @@ function EChartsRenderer({
       chartInstance.current?.dispose();
       chartInstance.current = null;
     };
-  }, [config]);
+  }, [config, customizations]);
 
   if (!config || Object.keys(config).length === 0) {
     return (
@@ -314,7 +329,11 @@ export function KPICard({
         {isLoading ? (
           <Skeleton className="h-32 w-full" />
         ) : (
-          <EChartsRenderer config={echartsConfig || {}} height="h-full" />
+          <EChartsRenderer
+            config={echartsConfig || {}}
+            height="h-full"
+            customizations={data.customizations}
+          />
         )}
       </div>
 

--- a/components/kpis/kpi-card.tsx
+++ b/components/kpis/kpi-card.tsx
@@ -15,7 +15,8 @@ import { Download, FileImage, FileText, Maximize2, MoreVertical } from 'lucide-r
 import { useFullscreen } from '@/hooks/useFullscreen';
 import { RAG_COLORS } from '@/types/kpis';
 import { toastSuccess, toastError } from '@/lib/toast';
-import { formatMetricValue } from '@/lib/formatters';
+import { formatKPIValue } from '@/lib/formatters';
+import type { KPICustomizations } from '@/types/kpis';
 import { OverflowTooltip } from '@/components/ui/overflow-tooltip';
 import type { RAGStatus } from '@/types/kpis';
 import { formatDistanceToNow, format as formatDate, parseISO, isValid } from 'date-fns';
@@ -85,6 +86,11 @@ export interface KPICardData {
   updatedAt: string;
   isLoading: boolean;
   periods?: { period: string; period_date?: string | null; value: number | null }[];
+  /**
+   * Display customizations for the current value + target. When undefined,
+   * the card falls back to the legacy compact display via formatKPIValue.
+   */
+  customizations?: KPICustomizations;
 }
 
 interface KPICardProps {
@@ -278,11 +284,11 @@ export function KPICard({
         ) : (
           <>
             <div className="text-4xl font-bold text-gray-900">
-              {formatMetricValue(currentValue)}
+              {formatKPIValue(currentValue, data.customizations)}
             </div>
             {targetValue !== null && targetValue !== undefined && (
               <p className="text-sm text-muted-foreground mt-0.5">
-                Target: {formatMetricValue(targetValue)}
+                Target: {formatKPIValue(targetValue, data.customizations)}
               </p>
             )}
             {popChange !== null && (

--- a/components/kpis/kpi-detail-drawer.tsx
+++ b/components/kpis/kpi-detail-drawer.tsx
@@ -3,7 +3,7 @@
 import { useState, useRef, useEffect } from 'react';
 import * as echarts from 'echarts';
 import { format as formatDate } from 'date-fns';
-import { formatMetricValue, computePopChanges } from '@/lib/formatters';
+import { formatMetricValue, formatKPIValue, computePopChanges } from '@/lib/formatters';
 import { useAuthStore } from '@/stores/authStore';
 import { Sheet, SheetContent } from '@/components/ui/sheet';
 import { Button } from '@/components/ui/button';
@@ -229,11 +229,11 @@ export function KPIDetailDrawer({
               ) : (
                 <>
                   <p className="text-4xl font-bold text-gray-900">
-                    {formatMetricValue(currentValue)}
+                    {formatKPIValue(currentValue, kpi.extra_config?.customizations)}
                   </p>
                   {kpi.target_value !== null && (
                     <p className="text-sm text-muted-foreground mt-0.5">
-                      Target: {formatMetricValue(kpi.target_value)}
+                      Target: {formatKPIValue(kpi.target_value, kpi.extra_config?.customizations)}
                     </p>
                   )}
                   {popChange !== null && (

--- a/components/kpis/kpi-detail-drawer.tsx
+++ b/components/kpis/kpi-detail-drawer.tsx
@@ -33,7 +33,7 @@ import {
   updateAnnotation,
   deleteAnnotation,
 } from '@/hooks/api/useKPIs';
-import type { KPI, NoteType } from '@/types/kpis';
+import type { KPI, NoteType, KPICustomizations } from '@/types/kpis';
 import type { RAGStatus } from '@/types/kpis';
 import { RAG_COLORS, TIME_GRAIN_OPTIONS } from '@/types/kpis';
 import { formatDistanceToNow } from 'date-fns';
@@ -61,7 +61,15 @@ interface KPIDetailDrawerProps {
   onDelete: () => void;
 }
 
-function TrendChart({ config, height = 'h-64' }: { config: Record<string, any>; height?: string }) {
+function TrendChart({
+  config,
+  height = 'h-64',
+  customizations,
+}: {
+  config: Record<string, any>;
+  height?: string;
+  customizations?: KPICustomizations;
+}) {
   const chartRef = useRef<HTMLDivElement>(null);
   const chartInstance = useRef<echarts.ECharts | null>(null);
 
@@ -72,7 +80,20 @@ function TrendChart({ config, height = 'h-64' }: { config: Record<string, any>; 
       chartInstance.current.dispose();
     }
     chartInstance.current = echarts.init(chartRef.current);
-    chartInstance.current.setOption(config);
+
+    // Inject tooltip valueFormatter so hover values match the drawer header's
+    // formatted current value + target.
+    const effectiveConfig = customizations
+      ? {
+          ...config,
+          tooltip: {
+            ...(config.tooltip || {}),
+            valueFormatter: (value: number | null) => formatKPIValue(value, customizations),
+          },
+        }
+      : config;
+
+    chartInstance.current.setOption(effectiveConfig);
 
     const handleResize = () => chartInstance.current?.resize();
     window.addEventListener('resize', handleResize);
@@ -82,7 +103,7 @@ function TrendChart({ config, height = 'h-64' }: { config: Record<string, any>; 
       chartInstance.current?.dispose();
       chartInstance.current = null;
     };
-  }, [config]);
+  }, [config, customizations]);
 
   if (!config || Object.keys(config).length === 0) {
     return (
@@ -305,7 +326,11 @@ export function KPIDetailDrawer({
           {isLoading ? (
             <Skeleton className="h-56 w-full" />
           ) : (
-            <TrendChart config={echartsConfig || {}} height="h-56" />
+            <TrendChart
+              config={echartsConfig || {}}
+              height="h-56"
+              customizations={kpi.extra_config?.customizations}
+            />
           )}
         </div>
 

--- a/components/kpis/kpi-form.tsx
+++ b/components/kpis/kpi-form.tsx
@@ -27,8 +27,11 @@ import { useTableColumns } from '@/hooks/api/useWarehouse';
 import { createKPI, updateKPI, useProgramTags } from '@/hooks/api/useKPIs';
 import { trackEvent } from '@/lib/analytics';
 import { ANALYTICS_EVENTS } from '@/constants/analytics';
-import type { KPI, KPICreate, KPIUpdate } from '@/types/kpis';
+import type { KPI, KPICreate, KPIUpdate, KPIExtraConfig } from '@/types/kpis';
 import { DIRECTION_OPTIONS, TIME_GRAIN_OPTIONS, METRIC_TYPE_TAG_OPTIONS } from '@/types/kpis';
+import type { NumberFormat } from '@/lib/formatters';
+import { NumberFormatSection } from '@/components/charts/types/shared/NumberFormatSection';
+import { DebouncedInput } from '@/components/charts/debounced-input';
 import { cn } from '@/lib/utils';
 
 const DATE_TYPES = [
@@ -51,6 +54,12 @@ interface KPIFormData {
   time_dimension_column: string;
   metric_type_tag: string;
   program_tags: string[];
+  // Display customizations (flat for react-hook-form ergonomics; nested back
+  // into ``extra_config.customizations`` on submit).
+  numberFormat: NumberFormat | '';
+  decimalPlaces: string;
+  numberPrefix: string;
+  numberSuffix: string;
 }
 
 interface KPIFormProps {
@@ -167,12 +176,16 @@ export function KPIForm({ open, onOpenChange, onSuccess, kpi, preselectedMetricI
       name: '',
       target_value: '',
       direction: 'increase',
-      green_threshold_pct: '100',
-      amber_threshold_pct: '80',
+      green_threshold_pct: '80',
+      amber_threshold_pct: '50',
       time_grain: 'monthly',
       time_dimension_column: '',
       metric_type_tag: '',
       program_tags: [],
+      numberFormat: '',
+      decimalPlaces: '',
+      numberPrefix: '',
+      numberSuffix: '',
     },
   });
 
@@ -203,6 +216,7 @@ export function KPIForm({ open, onOpenChange, onSuccess, kpi, preselectedMetricI
       mutateMetrics();
       if (kpi) {
         setStep(2); // Edit: show full form
+        const c = kpi.extra_config?.customizations;
         reset({
           metric_id: kpi.metric.id,
           name: kpi.name,
@@ -214,6 +228,10 @@ export function KPIForm({ open, onOpenChange, onSuccess, kpi, preselectedMetricI
           time_dimension_column: kpi.time_dimension_column || '',
           metric_type_tag: kpi.metric_type_tag || '',
           program_tags: kpi.program_tags || [],
+          numberFormat: c?.numberFormat ?? '',
+          decimalPlaces: c?.decimalPlaces != null ? c.decimalPlaces.toString() : '',
+          numberPrefix: c?.numberPrefix ?? '',
+          numberSuffix: c?.numberSuffix ?? '',
         });
       } else {
         setStep(1);
@@ -222,12 +240,16 @@ export function KPIForm({ open, onOpenChange, onSuccess, kpi, preselectedMetricI
           name: '',
           target_value: '',
           direction: 'increase',
-          green_threshold_pct: '100',
-          amber_threshold_pct: '80',
+          green_threshold_pct: '80',
+          amber_threshold_pct: '50',
           time_grain: 'monthly',
           time_dimension_column: '',
           metric_type_tag: '',
           program_tags: [],
+          numberFormat: '',
+          decimalPlaces: '',
+          numberPrefix: '',
+          numberSuffix: '',
         });
       }
       setSaveError(null);
@@ -262,6 +284,19 @@ export function KPIForm({ open, onOpenChange, onSuccess, kpi, preselectedMetricI
 
     const programTags = data.program_tags;
 
+    // Build the extra_config payload from the flat form fields. Skip fields
+    // the user did not set so the stored JSON stays clean (no empty strings).
+    const customizations: NonNullable<KPIExtraConfig['customizations']> = {};
+    if (data.numberFormat) customizations.numberFormat = data.numberFormat;
+    if (data.decimalPlaces !== '') {
+      const n = parseInt(data.decimalPlaces, 10);
+      if (!Number.isNaN(n)) customizations.decimalPlaces = n;
+    }
+    if (data.numberPrefix) customizations.numberPrefix = data.numberPrefix;
+    if (data.numberSuffix) customizations.numberSuffix = data.numberSuffix;
+    const extraConfig: KPIExtraConfig =
+      Object.keys(customizations).length > 0 ? { customizations } : {};
+
     try {
       if (isEdit && kpi) {
         const updateData: KPIUpdate = {
@@ -275,6 +310,7 @@ export function KPIForm({ open, onOpenChange, onSuccess, kpi, preselectedMetricI
           time_dimension_column: data.time_dimension_column || null,
           metric_type_tag: data.metric_type_tag || undefined,
           program_tags: programTags,
+          extra_config: extraConfig,
         };
         await updateKPI(kpi.id, updateData);
         trackEvent(ANALYTICS_EVENTS.KPI_UPDATED, {
@@ -292,6 +328,7 @@ export function KPIForm({ open, onOpenChange, onSuccess, kpi, preselectedMetricI
           time_dimension_column: data.time_dimension_column || null,
           metric_type_tag: data.metric_type_tag || undefined,
           program_tags: programTags,
+          extra_config: extraConfig,
         };
         await createKPI(createData);
         trackEvent(ANALYTICS_EVENTS.KPI_CREATED, {
@@ -401,11 +438,11 @@ export function KPIForm({ open, onOpenChange, onSuccess, kpi, preselectedMetricI
                   onValueChange={(v) => {
                     field.onChange(v);
                     if (v === 'increase') {
-                      setValue('green_threshold_pct', '100');
-                      setValue('amber_threshold_pct', '80');
-                    } else {
                       setValue('green_threshold_pct', '80');
-                      setValue('amber_threshold_pct', '100');
+                      setValue('amber_threshold_pct', '50');
+                    } else {
+                      setValue('green_threshold_pct', '50');
+                      setValue('amber_threshold_pct', '80');
                     }
                   }}
                 >
@@ -574,7 +611,8 @@ export function KPIForm({ open, onOpenChange, onSuccess, kpi, preselectedMetricI
                 </div>
               )}
 
-              {/* Program Tags */}
+              {/* Classification — Program Tags + KPI Type */}
+              <p className="text-sm text-muted-foreground font-medium mt-6 mb-1">Classification</p>
               <div className="space-y-1">
                 <Label>Program Tags</Label>
                 <Controller
@@ -621,6 +659,67 @@ export function KPIForm({ open, onOpenChange, onSuccess, kpi, preselectedMetricI
                     </div>
                   )}
                 />
+              </div>
+
+              {/* ── Display formatting (number format + prefix/suffix) ─── */}
+              <p className="text-sm text-muted-foreground font-medium mt-6 mb-1">
+                Display Formatting
+              </p>
+              <div className="space-y-2">
+                <Controller
+                  control={control}
+                  name="numberFormat"
+                  render={({ field: formatField }) => (
+                    <Controller
+                      control={control}
+                      name="decimalPlaces"
+                      render={({ field: decField }) => (
+                        <NumberFormatSection
+                          idPrefix="kpi"
+                          numberFormat={
+                            (formatField.value || undefined) as NumberFormat | undefined
+                          }
+                          decimalPlaces={decField.value === '' ? undefined : Number(decField.value)}
+                          onNumberFormatChange={(v) => formatField.onChange(v)}
+                          onDecimalPlacesChange={(v) => decField.onChange(String(v))}
+                        />
+                      )}
+                    />
+                  )}
+                />
+
+                <div className="grid grid-cols-2 gap-3">
+                  <div className="space-y-1">
+                    <Label htmlFor="kpi-numberPrefix">Prefix</Label>
+                    <Controller
+                      control={control}
+                      name="numberPrefix"
+                      render={({ field }) => (
+                        <DebouncedInput
+                          id="kpi-numberPrefix"
+                          value={field.value}
+                          onChange={field.onChange}
+                          placeholder="e.g., ₹, $, +"
+                        />
+                      )}
+                    />
+                  </div>
+                  <div className="space-y-1">
+                    <Label htmlFor="kpi-numberSuffix">Suffix</Label>
+                    <Controller
+                      control={control}
+                      name="numberSuffix"
+                      render={({ field }) => (
+                        <DebouncedInput
+                          id="kpi-numberSuffix"
+                          value={field.value}
+                          onChange={field.onChange}
+                          placeholder="e.g., %, people, kg"
+                        />
+                      )}
+                    />
+                  </div>
+                </div>
               </div>
             </>
           )}

--- a/components/kpis/kpi-page.tsx
+++ b/components/kpis/kpi-page.tsx
@@ -93,6 +93,7 @@ function KPICardWithData({
     updatedAt: kpi.updated_at,
     isLoading,
     periods,
+    customizations: kpi.extra_config?.customizations,
   };
 
   return (

--- a/lib/formatters.ts
+++ b/lib/formatters.ts
@@ -117,6 +117,46 @@ export function formatMetricValue(v: number | null | undefined): string {
 }
 
 /**
+ * Customizations subset accepted by formatKPIValue. Matches the shape on
+ * KPI.extra_config.customizations. All fields optional.
+ */
+type FormatKPIValueCustomizations = {
+  numberFormat?: NumberFormat;
+  decimalPlaces?: number;
+  numberPrefix?: string;
+  numberSuffix?: string;
+};
+
+/**
+ * Render a KPI value with user-configured number formatting and prefix/suffix.
+ * When no customizations are set, shows the raw number as-is (no grouping,
+ * no compression).
+ *
+ * Returns "No data" for null/NaN -- without wrapping prefix/suffix. Matches
+ * the backend format_number_v2 contract so alert emails and the KPI card
+ * stay byte-identical.
+ */
+export function formatKPIValue(
+  value: number | null | undefined,
+  customizations?: FormatKPIValueCustomizations
+): string {
+  if (value === null || value === undefined || Number.isNaN(value)) {
+    return 'No data';
+  }
+  if (!customizations || !customizations.numberFormat) {
+    // No formatting configured -- show the raw number as-is
+    return String(value);
+  }
+  const formatted = formatNumber(value, {
+    format: customizations.numberFormat,
+    decimalPlaces: customizations.decimalPlaces,
+  });
+  const prefix = customizations.numberPrefix ?? '';
+  const suffix = customizations.numberSuffix ?? '';
+  return `${prefix}${formatted}${suffix}`;
+}
+
+/**
  * Compute period-over-period percentage changes for a list of values.
  * Returns an array of the same length where each element is the % change
  * from the previous value, or null if it can't be computed.

--- a/lib/formatters.ts
+++ b/lib/formatters.ts
@@ -13,7 +13,6 @@ export const NumberFormats = {
   INDIAN: 'indian',
   EUROPEAN: 'european',
   PERCENTAGE: 'percentage',
-  CURRENCY: 'currency',
   ADAPTIVE_INTERNATIONAL: 'adaptive_international',
   ADAPTIVE_INDIAN: 'adaptive_indian',
 } as const;
@@ -35,7 +34,7 @@ export interface FormatOptions {
  * @example
  * formatNumber(1000000, { format: 'international', decimalPlaces: 2 }) // "1,000,000.00"
  * formatNumber(1000000, { format: 'indian' })                          // "10,00,000"
- * formatNumber(85.5, { format: 'percentage' })                         // "85.5%"
+ * formatNumber(0.855, { format: 'percentage', decimalPlaces: 1 })      // "85.5%" (value * 100)
  */
 /**
  * Date format types supported by the application
@@ -215,21 +214,13 @@ export function formatNumber(value: number, options: FormatOptions | NumberForma
         maximumFractionDigits: decimalPlaces,
       });
 
-    case NumberFormats.PERCENTAGE:
-      // 85 → 85%
-      const percentValue =
-        decimalPlaces !== undefined ? processedValue.toFixed(decimalPlaces) : value.toString();
-      return percentValue + '%';
-
-    case NumberFormats.CURRENCY:
-      // 1000 → $1,000
-      return (
-        '$' +
-        processedValue.toLocaleString('en-US', {
-          minimumFractionDigits: decimalPlaces,
-          maximumFractionDigits: decimalPlaces,
-        })
-      );
+    case NumberFormats.PERCENTAGE: {
+      // Percentage semantics: value is a ratio (0.85 → "85.00%"). Multiply by
+      // 100 before rendering. Decimal places apply to the scaled number.
+      const scaled = value * 100;
+      const text = decimalPlaces !== undefined ? scaled.toFixed(decimalPlaces) : scaled.toString();
+      return text + '%';
+    }
 
     case NumberFormats.ADAPTIVE_INTERNATIONAL: {
       // International SI-like notation: K, M, B

--- a/types/kpis.ts
+++ b/types/kpis.ts
@@ -1,4 +1,5 @@
 import type { Metric } from './metrics';
+import type { NumberFormat } from '@/lib/formatters';
 
 export type RAGStatus = 'green' | 'amber' | 'red';
 
@@ -36,6 +37,27 @@ export const METRIC_TYPE_TAG_OPTIONS = [
   { value: 'impact', label: 'Impact' },
 ] as const;
 
+/**
+ * Display customizations for a KPI value. Mirrors the backend
+ * ``NumberChartCustomizations`` schema — the same shape used by the number chart.
+ * All fields optional; consumers must guard before reading.
+ */
+export interface KPICustomizations {
+  numberFormat?: NumberFormat;
+  decimalPlaces?: number;
+  numberPrefix?: string;
+  numberSuffix?: string;
+}
+
+/**
+ * Typed container for ``KPI.extra_config``. Always present on responses (the
+ * backend column has ``default=dict, null=False``). ``customizations`` inside
+ * is optional — must be checked before reading.
+ */
+export interface KPIExtraConfig {
+  customizations?: KPICustomizations;
+}
+
 export interface KPI {
   id: number;
   name: string;
@@ -49,6 +71,7 @@ export interface KPI {
   metric_type_tag: string | null;
   program_tags: string[];
   display_order: number;
+  extra_config: KPIExtraConfig; // always present
   created_by?: string; // creator's email
   created_at: string;
   updated_at: string;
@@ -65,6 +88,7 @@ export interface KPICreate {
   time_dimension_column: string;
   metric_type_tag?: string;
   program_tags?: string[];
+  extra_config: KPIExtraConfig; // required — form always sends it
 }
 
 export interface KPIUpdate {
@@ -79,6 +103,7 @@ export interface KPIUpdate {
   metric_type_tag?: string;
   program_tags?: string[];
   display_order?: number;
+  extra_config: KPIExtraConfig; // required on every update
 }
 
 export interface KPIListResponse {
@@ -98,6 +123,10 @@ export interface KPIDataPayload {
   time_grain: string;
   periods: { period: string; period_date: string | null; value: number | null }[];
   data_last_date: string | null;
+  // Display customizations (surfaced so the dashboard widget / snapshot
+  // viewer can format the current value without a second fetch). Null when
+  // the KPI has no formatting configured.
+  customizations: KPICustomizations | null;
 }
 
 export type NoteType = 'beneficiary_quote' | 'note';


### PR DESCRIPTION
Main changes
- Ability to format kpis, similar to number chart
- Alerts built on KPIs will send the same formatted value
- KPI Wigets on dashboards and the frozen reports will show the formatted kpi card
- KPI annotation view will also show the formatted kpi value

Refactor
- Removed currency number format from all chart types because it was only prefixing the value & not actually doing any number format. Discussed this with product
- % percentage number format everywhere now does this : (0.85 ==> 85%) basically multiply by 100. 
- Commands on backend to handle created charts & reports for this change.