### PR TITLE
fix: show KPIs on public dashboard for unauthenticated users

### DIFF
--- a/components/dashboard/dashboard-native-view.tsx
+++ b/components/dashboard/dashboard-native-view.tsx
@@ -675,6 +675,8 @@ export function DashboardNativeView({
               dashboardFilters={selectedFilters}
               snapshotId={isReportMode ? snapshotId : undefined}
               publicToken={publicToken}
+              isPublicMode={isPublicMode}
+              isReportMode={isReportMode}
               commentStates={isReportMode ? commentStates : undefined}
               onCommentStateChange={isReportMode ? onCommentStateChange : undefined}
               autoOpenCommentChartId={isReportMode ? autoOpenCommentChartId : undefined}

--- a/components/dashboard/dashboard-native-view.tsx
+++ b/components/dashboard/dashboard-native-view.tsx
@@ -674,6 +674,7 @@ export function DashboardNativeView({
               config={component.config}
               dashboardFilters={selectedFilters}
               snapshotId={isReportMode ? snapshotId : undefined}
+              publicToken={publicToken}
               commentStates={isReportMode ? commentStates : undefined}
               onCommentStateChange={isReportMode ? onCommentStateChange : undefined}
               autoOpenCommentChartId={isReportMode ? autoOpenCommentChartId : undefined}

--- a/components/dashboard/kpi-chart-element.tsx
+++ b/components/dashboard/kpi-chart-element.tsx
@@ -14,6 +14,7 @@ interface KPIChartElementProps {
   isResizing?: boolean;
   snapshotId?: number;
   dashboardFilters?: Record<string, any>;
+  publicToken?: string;
   commentStates?: CommentStates;
   onCommentStateChange?: () => void;
   autoOpenCommentChartId?: string;
@@ -24,18 +25,22 @@ export function KPIChartElement({
   config,
   snapshotId,
   dashboardFilters,
+  publicToken,
   commentStates,
   onCommentStateChange,
   autoOpenCommentChartId,
 }: KPIChartElementProps) {
   const { chartData, echartsConfig, isLoading, isError } = useKPIData(kpiId, snapshotId, {
     dashboardFilters,
+    publicToken,
   });
 
   const ragStatus = chartData?.rag_status as RAGStatus | null;
   const periods = chartData?.periods || [];
 
-  const lastTwo = periods.slice(-2).map((p) => p.value);
+  const lastTwo = periods
+    .slice(-2)
+    .map((p: { period: string; period_date: string | null; value: number | null }) => p.value);
   const popChange = computePopChanges(lastTwo)[1] ?? null;
 
   if (isError) {

--- a/components/dashboard/kpi-chart-element.tsx
+++ b/components/dashboard/kpi-chart-element.tsx
@@ -1,12 +1,12 @@
 'use client';
 
-import { useKPIData } from '@/hooks/api/useKPIs';
 import { KPICard } from '@/components/kpis/kpi-card';
 import type { KPICardData } from '@/components/kpis/kpi-card';
 import type { RAGStatus } from '@/types/kpis';
 import type { CommentStates, CommentIconState } from '@/types/comments';
 import { CommentPopover } from '@/components/reports/comment-popover';
 import { computePopChanges } from '@/lib/formatters';
+import { useKPIData } from '@/hooks/api/useKPIs';
 
 interface KPIChartElementProps {
   kpiId: number;
@@ -15,6 +15,8 @@ interface KPIChartElementProps {
   snapshotId?: number;
   dashboardFilters?: Record<string, any>;
   publicToken?: string;
+  isPublicMode?: boolean;
+  isReportMode?: boolean;
   commentStates?: CommentStates;
   onCommentStateChange?: () => void;
   autoOpenCommentChartId?: string;
@@ -26,13 +28,17 @@ export function KPIChartElement({
   snapshotId,
   dashboardFilters,
   publicToken,
+  isPublicMode,
+  isReportMode,
   commentStates,
   onCommentStateChange,
   autoOpenCommentChartId,
 }: KPIChartElementProps) {
-  const { chartData, echartsConfig, isLoading, isError } = useKPIData(kpiId, snapshotId, {
+  const { chartData, echartsConfig, isError, isLoading } = useKPIData(kpiId || null, snapshotId, {
     dashboardFilters,
     publicToken,
+    isPublicMode,
+    isReportMode,
   });
 
   const ragStatus = chartData?.rag_status as RAGStatus | null;

--- a/hooks/api/useKPIs.ts
+++ b/hooks/api/useKPIs.ts
@@ -1,5 +1,5 @@
 import useSWR from 'swr';
-import { apiGet, apiPost, apiPut, apiDelete } from '@/lib/api';
+import { apiGet, apiPost, apiPut, apiDelete, apiPublicGet } from '@/lib/api';
 import type {
   KPI,
   KPICreate,
@@ -63,6 +63,7 @@ export function useKPIData(
     dateFrom?: string;
     dateTo?: string;
     dashboardFilters?: Record<string, any>;
+    publicToken?: string;
   }
 ) {
   let url: string | null = null;
@@ -74,6 +75,13 @@ export function useKPIData(
       }
       const qs = params.toString();
       url = `/api/reports/${snapshotId}/kpis/${id}/data/${qs ? `?${qs}` : ''}`;
+    } else if (options?.publicToken) {
+      const params = new URLSearchParams();
+      if (options?.dashboardFilters && Object.keys(options.dashboardFilters).length > 0) {
+        params.append('dashboard_filters', JSON.stringify(options.dashboardFilters));
+      }
+      const qs = params.toString();
+      url = `/api/v1/public/dashboards/${options.publicToken}/kpis/${id}/data/${qs ? `?${qs}` : ''}`;
     } else {
       const params = new URLSearchParams();
       if (options?.timeGrain) params.append('time_grain', options.timeGrain);
@@ -87,7 +95,8 @@ export function useKPIData(
     }
   }
 
-  const { data, error } = useSWR<ChartDataResponse>(url, apiGet);
+  const fetcher = options?.publicToken ? apiPublicGet : apiGet;
+  const { data, error } = useSWR<ChartDataResponse>(url, fetcher);
 
   return {
     chartData: data?.data,

--- a/hooks/api/useKPIs.ts
+++ b/hooks/api/useKPIs.ts
@@ -64,6 +64,8 @@ export function useKPIData(
     dateTo?: string;
     dashboardFilters?: Record<string, any>;
     publicToken?: string;
+    isPublicMode?: boolean;
+    isReportMode?: boolean;
   }
 ) {
   let url: string | null = null;
@@ -75,7 +77,14 @@ export function useKPIData(
       }
       const qs = params.toString();
       url = `/api/reports/${snapshotId}/kpis/${id}/data/${qs ? `?${qs}` : ''}`;
-    } else if (options?.publicToken) {
+    } else if (options?.isPublicMode && options?.isReportMode && options?.publicToken) {
+      const params = new URLSearchParams();
+      if (options?.dashboardFilters && Object.keys(options.dashboardFilters).length > 0) {
+        params.append('dashboard_filters', JSON.stringify(options.dashboardFilters));
+      }
+      const qs = params.toString();
+      url = `/api/v1/public/reports/${options.publicToken}/kpis/${id}/data/${qs ? `?${qs}` : ''}`;
+    } else if (options?.isPublicMode && options?.publicToken) {
       const params = new URLSearchParams();
       if (options?.dashboardFilters && Object.keys(options.dashboardFilters).length > 0) {
         params.append('dashboard_filters', JSON.stringify(options.dashboardFilters));
@@ -95,7 +104,7 @@ export function useKPIData(
     }
   }
 
-  const fetcher = options?.publicToken ? apiPublicGet : apiGet;
+  const fetcher = options?.isPublicMode ? apiPublicGet : apiGet;
   const { data, error } = useSWR<ChartDataResponse>(url, fetcher);
 
   return {


### PR DESCRIPTION
## Summary
- KPIs were not visible on public (shared) dashboards for unauthenticated users
- Added `publicToken` prop to `KPIChartElement` and passed it from `dashboard-native-view`
- `useKPIData` now calls the public endpoint when `publicToken` is present, using `apiPublicGet` instead of `apiGet`