### PR TITLE
Resource sharing enforcement (dashboards): my_access-based edit gating

### DIFF
--- a/app/dashboards/[id]/edit/page.tsx
+++ b/app/dashboards/[id]/edit/page.tsx
@@ -5,7 +5,6 @@ import { useEffect, useRef, useState } from 'react';
 import { DashboardBuilderV2 } from '@/components/dashboard/dashboard-builder-v2';
 import { useDashboard } from '@/hooks/api/useDashboards';
 import { useAuthStore } from '@/stores/authStore';
-import { PERMISSIONS, useRbac } from '@/lib/rbac';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { ArrowLeft, Lock, User, Clock, AlertTriangle, Eye, Loader2 } from 'lucide-react';
@@ -23,17 +22,14 @@ export default function EditDashboardPage() {
   const getCurrentOrgUser = useAuthStore((state) => state.getCurrentOrgUser);
   const currentUser = getCurrentOrgUser();
 
-  // Get user permissions
-  const { hasPermission } = useRbac();
-  const canEditDashboard = hasPermission(PERMISSIONS.CAN_EDIT_DASHBOARDS);
+  // Fetch the dashboard. A viewer (member with view access) can load it — the
+  // backend returns 404 if they can't even view. Whether they may *edit* is
+  // gated below on the per-resource `my_access`, not on a role permission.
+  const { data: dashboard, isLoading, isError, mutate } = useDashboard(dashboardId);
 
-  // Don't start the dashboard request without edit permission
-  const {
-    data: dashboard,
-    isLoading,
-    isError,
-    mutate,
-  } = useDashboard(canEditDashboard ? dashboardId : null);
+  // Can this user EDIT this specific dashboard? Per-resource access from the API
+  // (grants + org floor + ownership). Undefined until the dashboard loads.
+  const canEditDashboard = dashboard?.my_access === 'edit';
 
   // Check if dashboard is locked by another user
   // Only block access if dashboard is locked AND locked by someone else
@@ -193,8 +189,22 @@ export default function EditDashboardPage() {
     },
   };
 
-  // Check if user has edit permissions — before the loading check, since the
-  // dashboard request never starts (and never resolves) without permission
+  // Loading comes first now: canEditDashboard depends on the fetched dashboard,
+  // so we can't gate on it until the request resolves.
+  if (isLoading) {
+    return (
+      <div className="h-screen flex items-center justify-center">
+        <div className="text-center">
+          <div className="animate-spin h-8 w-8 border-4 border-primary border-t-transparent rounded-full mx-auto mb-4"></div>
+          <p className="text-muted-foreground">Loading dashboard...</p>
+        </div>
+      </div>
+    );
+  }
+
+  // After load: the dashboard is visible to this user (else the backend 404'd),
+  // but editing requires per-resource edit access. View-only users are stopped
+  // here rather than in the builder.
   if (!canEditDashboard) {
     return (
       <div className="h-screen flex items-center justify-center">
@@ -203,24 +213,11 @@ export default function EditDashboardPage() {
             <Lock className="w-6 h-6 text-red-600" />
           </div>
           <h2 className="text-xl font-semibold mb-2">Access Denied</h2>
-          <p className="text-muted-foreground mb-4">
-            You don't have permission to edit dashboards.
-          </p>
+          <p className="text-muted-foreground mb-4">You have view-only access to this dashboard.</p>
           <Button variant="outline" onClick={() => router.push('/dashboards')}>
             <ArrowLeft className="w-4 h-4 mr-2" />
             Back to Dashboards
           </Button>
-        </div>
-      </div>
-    );
-  }
-
-  if (isLoading) {
-    return (
-      <div className="h-screen flex items-center justify-center">
-        <div className="text-center">
-          <div className="animate-spin h-8 w-8 border-4 border-primary border-t-transparent rounded-full mx-auto mb-4"></div>
-          <p className="text-muted-foreground">Loading dashboard...</p>
         </div>
       </div>
     );

--- a/app/dashboards/[id]/edit/page.tsx
+++ b/app/dashboards/[id]/edit/page.tsx
@@ -24,12 +24,12 @@ export default function EditDashboardPage() {
 
   // Fetch the dashboard. A viewer (member with view access) can load it — the
   // backend returns 404 if they can't even view. Whether they may *edit* is
-  // gated below on the per-resource `my_access`, not on a role permission.
+  // gated below on the per-resource `access_level`, not on a role permission.
   const { data: dashboard, isLoading, isError, mutate } = useDashboard(dashboardId);
 
   // Can this user EDIT this specific dashboard? Per-resource access from the API
   // (grants + org floor + ownership). Undefined until the dashboard loads.
-  const canEditDashboard = dashboard?.my_access === 'edit';
+  const canEditDashboard = dashboard?.access_level === 'edit';
 
   // Check if dashboard is locked by another user
   // Only block access if dashboard is locked AND locked by someone else

--- a/components/dashboard/dashboard-list-v2.tsx
+++ b/components/dashboard/dashboard-list-v2.tsx
@@ -889,7 +889,7 @@ export function DashboardListV2() {
         {/* Actions Column */}
         <TableCell className="py-4">
           <div className="flex items-center gap-2">
-            {hasPermission(PERMISSIONS.CAN_EDIT_DASHBOARDS) && (
+            {dashboard.my_access === 'edit' && (
               <Link href={`/dashboards/${dashboard.id}/edit`}>
                 <Button variant="ghost" size="icon" className="h-8 w-8 p-0 hover:bg-gray-100">
                   <Edit className="w-4 h-4 text-gray-600" />
@@ -1082,7 +1082,7 @@ export function DashboardListV2() {
             </TooltipProvider>
 
             {/* Edit Button */}
-            {hasPermission(PERMISSIONS.CAN_EDIT_DASHBOARDS) && (
+            {dashboard.my_access === 'edit' && (
               <Link href={`/dashboards/${dashboard.id}/edit`}>
                 <Button
                   variant="outline"
@@ -1417,7 +1417,7 @@ export function DashboardListV2() {
 
             {/* Action Buttons - Edit and Share as icon-only buttons */}
             <div className="flex items-center gap-2 ml-4">
-              {hasPermission(PERMISSIONS.CAN_EDIT_DASHBOARDS) && (
+              {dashboard.my_access === 'edit' && (
                 <Link href={`/dashboards/${dashboard.id}/edit`}>
                   <Button
                     variant="outline"

--- a/components/dashboard/dashboard-list-v2.tsx
+++ b/components/dashboard/dashboard-list-v2.tsx
@@ -889,7 +889,7 @@ export function DashboardListV2() {
         {/* Actions Column */}
         <TableCell className="py-4">
           <div className="flex items-center gap-2">
-            {dashboard.my_access === 'edit' && (
+            {dashboard.access_level === 'edit' && (
               <Link href={`/dashboards/${dashboard.id}/edit`}>
                 <Button variant="ghost" size="icon" className="h-8 w-8 p-0 hover:bg-gray-100">
                   <Edit className="w-4 h-4 text-gray-600" />
@@ -1082,7 +1082,7 @@ export function DashboardListV2() {
             </TooltipProvider>
 
             {/* Edit Button */}
-            {dashboard.my_access === 'edit' && (
+            {dashboard.access_level === 'edit' && (
               <Link href={`/dashboards/${dashboard.id}/edit`}>
                 <Button
                   variant="outline"
@@ -1417,7 +1417,7 @@ export function DashboardListV2() {
 
             {/* Action Buttons - Edit and Share as icon-only buttons */}
             <div className="flex items-center gap-2 ml-4">
-              {dashboard.my_access === 'edit' && (
+              {dashboard.access_level === 'edit' && (
                 <Link href={`/dashboards/${dashboard.id}/edit`}>
                   <Button
                     variant="outline"

--- a/components/dashboard/dashboard-native-view.tsx
+++ b/components/dashboard/dashboard-native-view.tsx
@@ -354,11 +354,11 @@ export function DashboardNativeView({
   const { hasPermission } = useRbac();
 
   // Can this user edit THIS dashboard? Per-resource access (grants + org floor
-  // + ownership), surfaced by the API as `my_access`. Not the role permission —
-  // a member granted edit has my_access === "edit" but no role edit slug.
+  // + ownership), surfaced by the API as `access_level`. Not the role permission —
+  // a member granted edit has access_level === "edit" but no role edit slug.
   const canEdit = useMemo(() => {
     if (isPublicMode || !dashboard || !currentUser) return false;
-    return dashboard.my_access === 'edit';
+    return dashboard.access_level === 'edit';
   }, [isPublicMode, dashboard, currentUser]);
 
   // Check if dashboard is locked

--- a/components/dashboard/dashboard-native-view.tsx
+++ b/components/dashboard/dashboard-native-view.tsx
@@ -353,11 +353,13 @@ export function DashboardNativeView({
   // Get user permissions
   const { hasPermission } = useRbac();
 
-  // Check if user can edit - requires can_edit_dashboards permission
+  // Can this user edit THIS dashboard? Per-resource access (grants + org floor
+  // + ownership), surfaced by the API as `my_access`. Not the role permission —
+  // a member granted edit has my_access === "edit" but no role edit slug.
   const canEdit = useMemo(() => {
     if (isPublicMode || !dashboard || !currentUser) return false;
-    return hasPermission(PERMISSIONS.CAN_EDIT_DASHBOARDS);
-  }, [isPublicMode, dashboard, currentUser, hasPermission]);
+    return dashboard.my_access === 'edit';
+  }, [isPublicMode, dashboard, currentUser]);
 
   // Check if dashboard is locked
   const isLocked = dashboard?.is_locked || false;

--- a/hooks/api/useDashboards.ts
+++ b/hooks/api/useDashboards.ts
@@ -30,7 +30,7 @@ export interface Dashboard {
   // The requestor's own access level on this dashboard ("view" | "edit"),
   // computed per-request from grants + org floor + ownership. Drives whether
   // edit affordances show. Optional: absent from public views / legacy responses.
-  my_access?: 'view' | 'edit';
+  access_level?: 'view' | 'edit';
   // Sharing fields
   is_public: boolean;
   public_share_token?: string;

--- a/hooks/api/useDashboards.ts
+++ b/hooks/api/useDashboards.ts
@@ -27,6 +27,10 @@ export interface Dashboard {
   created_at: string;
   updated_at: string;
   filters: DashboardFilter[];
+  // The requestor's own access level on this dashboard ("view" | "edit"),
+  // computed per-request from grants + org floor + ownership. Drives whether
+  // edit affordances show. Optional: absent from public views / legacy responses.
+  my_access?: 'view' | 'edit';
   // Sharing fields
   is_public: boolean;
   public_share_token?: string;


### PR DESCRIPTION
## What

Frontend mirror of the dashboard access enforcement. Members now **see and can use** the Edit button exactly where the API allows it, and view-only users no longer see buttons that would 403.

Pairs with **DDP_backend #1439** (access resolver + decorators).

## How

The UI previously decided edit-ability from the `can_edit_dashboards` **role** permission — which a member never holds, even when granted edit on a specific dashboard. Switched to the per-dashboard `my_access` field the API now returns.

- **`hooks/api/useDashboards.ts`** — `Dashboard` gains `my_access?: 'view' | 'edit'`.
- **`dashboard-list-v2.tsx`** — the 3 per-row Edit buttons gate on `dashboard.my_access === 'edit'`.
- **`dashboard-native-view.tsx`** — `canEdit` derives from `my_access`.
- **`app/dashboards/[id]/edit/page.tsx`** — restructured: the fetch was gated on the role permission (so members hit a dead end); it now fetches on view access, derives `canEditDashboard` from the loaded `my_access`, reorders guards (loading before the edit gate), and the denial copy reads "view-only access".

## Effect

| User on a dashboard | Before | After |
|---|---|---|
| Member with edit (grant/floor) | no Edit button | sees & uses Edit |
| Analyst on a view-floor dashboard | saw Edit, save 403'd | no Edit button |
| Owner / admin | Edit | Edit |

Requires the backend PR for `my_access` to be present in responses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)