### PR TITLE
show Chart Data tab for table/pivot charts and add hover tooltips for…

### DIFF
--- a/app/charts/[id]/edit/page.tsx
+++ b/app/charts/[id]/edit/page.tsx
@@ -1818,41 +1818,44 @@ function EditChartPageContent() {
                     }
                     className="h-full flex flex-col"
                   >
-                    <TabsList
-                      className={`grid w-full ${formData.chart_type === ChartTypes.TABLE || formData.chart_type === ChartTypes.PIVOT_TABLE ? 'grid-cols-1' : 'grid-cols-2'} flex-shrink-0`}
-                    >
-                      {formData.chart_type !== ChartTypes.TABLE &&
-                        formData.chart_type !== ChartTypes.PIVOT_TABLE && (
-                          <TabsTrigger value="chart-data" className="flex items-center gap-2">
-                            <BarChart3 className="h-4 w-4" />
-                            Chart Data
-                          </TabsTrigger>
-                        )}
+                    <TabsList className="grid w-full grid-cols-2 flex-shrink-0">
+                      <TabsTrigger value="chart-data" className="flex items-center gap-2">
+                        <BarChart3 className="h-4 w-4" />
+                        Chart Data
+                      </TabsTrigger>
                       <TabsTrigger value="raw-data" className="flex items-center gap-2">
                         <Database className="h-4 w-4" />
                         Raw Data
                       </TabsTrigger>
                     </TabsList>
 
-                    {formData.chart_type !== ChartTypes.TABLE &&
-                      formData.chart_type !== ChartTypes.PIVOT_TABLE && (
-                        <TabsContent value="chart-data" className="flex-1 overflow-auto">
-                          <DataPreview
-                            data={Array.isArray(dataPreview?.data) ? dataPreview.data : []}
-                            columns={dataPreview?.columns || []}
-                            columnTypes={dataPreview?.column_types || {}}
-                            isLoading={previewLoading}
-                            error={previewError}
-                            pagination={{
-                              page: dataPreviewPage,
-                              pageSize: dataPreviewPageSize,
-                              total: chartDataTotalRows || 0,
-                              onPageChange: setDataPreviewPage,
-                              onPageSizeChange: handleDataPreviewPageSizeChange,
-                            }}
-                          />
-                        </TabsContent>
+                    <TabsContent value="chart-data" className="flex-1 overflow-auto">
+                      {formData.chart_type === ChartTypes.PIVOT_TABLE ? (
+                        <ChartPreview
+                          config={{ extra_config: formData.extra_config }}
+                          tableData={chartData?.data}
+                          isLoading={chartDataLoading}
+                          error={null}
+                          chartType={formData.chart_type}
+                          customizations={formData.customizations}
+                        />
+                      ) : (
+                        <DataPreview
+                          data={Array.isArray(dataPreview?.data) ? dataPreview.data : []}
+                          columns={dataPreview?.columns || []}
+                          columnTypes={dataPreview?.column_types || {}}
+                          isLoading={previewLoading}
+                          error={previewError}
+                          pagination={{
+                            page: dataPreviewPage,
+                            pageSize: dataPreviewPageSize,
+                            total: chartDataTotalRows || 0,
+                            onPageChange: setDataPreviewPage,
+                            onPageSizeChange: handleDataPreviewPageSizeChange,
+                          }}
+                        />
                       )}
+                    </TabsContent>
 
                     <TabsContent value="raw-data" className="flex-1 overflow-auto">
                       <DataPreview

--- a/app/charts/new/configure/page.tsx
+++ b/app/charts/new/configure/page.tsx
@@ -1300,23 +1300,28 @@ function ConfigureChartPageContent() {
                     }
                     className="h-full flex flex-col"
                   >
-                    <TabsList
-                      className={`grid w-full ${formData.chart_type === 'table' || formData.chart_type === 'pivot_table' ? 'grid-cols-1' : 'grid-cols-2'}`}
-                    >
-                      {formData.chart_type !== 'table' && formData.chart_type !== 'pivot_table' && (
-                        <TabsTrigger value="chart-data" className="flex items-center gap-2">
-                          <BarChart3 className="h-4 w-4" />
-                          Chart Data
-                        </TabsTrigger>
-                      )}
+                    <TabsList className="grid w-full grid-cols-2">
+                      <TabsTrigger value="chart-data" className="flex items-center gap-2">
+                        <BarChart3 className="h-4 w-4" />
+                        Chart Data
+                      </TabsTrigger>
                       <TabsTrigger value="raw-data" className="flex items-center gap-2">
                         <Database className="h-4 w-4" />
                         Raw Data
                       </TabsTrigger>
                     </TabsList>
 
-                    {formData.chart_type !== 'table' && formData.chart_type !== 'pivot_table' && (
-                      <TabsContent value="chart-data" className="flex-1">
+                    <TabsContent value="chart-data" className="flex-1">
+                      {formData.chart_type === 'pivot_table' ? (
+                        <ChartPreview
+                          config={{ extra_config: formData.extra_config }}
+                          tableData={chartData?.data}
+                          isLoading={chartLoading}
+                          error={chartError}
+                          chartType={formData.chart_type}
+                          customizations={formData.customizations}
+                        />
+                      ) : (
                         <DataPreview
                           data={Array.isArray(dataPreview?.data) ? dataPreview.data : []}
                           columns={dataPreview?.columns || []}
@@ -1331,8 +1336,8 @@ function ConfigureChartPageContent() {
                             onPageSizeChange: handleDataPreviewPageSizeChange,
                           }}
                         />
-                      </TabsContent>
-                    )}
+                      )}
+                    </TabsContent>
 
                     <TabsContent value="raw-data" className="flex-1">
                       <DataPreview

--- a/components/charts/ChartDataConfigurationV3.tsx
+++ b/components/charts/ChartDataConfigurationV3.tsx
@@ -22,6 +22,7 @@ import {
 } from '@/lib/columnTypeIcons';
 import { DatePicker } from '@/components/ui/date-picker';
 import { Combobox, highlightText } from '@/components/ui/combobox';
+import { TooltipLabel } from '@/components/charts/types/shared/TooltipLabel';
 import { ChartTypeSelector } from '@/components/charts/ChartTypeSelector';
 import { MetricsSelector } from '@/components/charts/MetricsSelector';
 import { DatasetSelector } from '@/components/charts/DatasetSelector';
@@ -555,7 +556,9 @@ export function ChartDataConfigurationV3({
               renderItem={(item, _isSelected, searchQuery) => (
                 <div className="flex items-center gap-2 min-w-0">
                   <ColumnTypeIcon dataType={item.data_type} className="w-4 h-4" />
-                  <span className="truncate">{highlightText(item.label, searchQuery)}</span>
+                  <TooltipLabel label={item.label}>
+                    {highlightText(item.label, searchQuery)}
+                  </TooltipLabel>
                 </div>
               )}
             />
@@ -740,7 +743,9 @@ export function ChartDataConfigurationV3({
             renderItem={(item, _isSelected, searchQuery) => (
               <div className="flex items-center gap-2 min-w-0">
                 {item.data_type && <ColumnTypeIcon dataType={item.data_type} className="w-4 h-4" />}
-                <span className="truncate">{highlightText(item.label, searchQuery)}</span>
+                <TooltipLabel label={item.label}>
+                  {highlightText(item.label, searchQuery)}
+                </TooltipLabel>
               </div>
             )}
           />
@@ -784,7 +789,9 @@ export function ChartDataConfigurationV3({
                     renderItem={(item, _isSelected, searchQuery) => (
                       <div className="flex items-center gap-2 min-w-0">
                         <ColumnTypeIcon dataType={item.data_type} className="w-4 h-4" />
-                        <span className="truncate">{highlightText(item.label, searchQuery)}</span>
+                        <TooltipLabel label={item.label}>
+                          {highlightText(item.label, searchQuery)}
+                        </TooltipLabel>
                       </div>
                     )}
                   />
@@ -1014,10 +1021,10 @@ export function ChartDataConfigurationV3({
                       placeholder="Select column to sort"
                       compact
                       renderItem={(item, _isSelected, searchQuery) => (
-                        <div className="flex items-center gap-2">
+                        <div className="flex items-center gap-2 min-w-0">
                           {item.type && (
                             <span
-                              className={`inline-flex items-center rounded px-2 py-0.5 text-xs font-medium ${
+                              className={`inline-flex items-center rounded px-2 py-0.5 text-xs font-medium shrink-0 ${
                                 item.type === 'column'
                                   ? 'bg-blue-100 text-blue-800'
                                   : 'bg-green-100 text-green-800'
@@ -1026,7 +1033,9 @@ export function ChartDataConfigurationV3({
                               {item.type === 'column' ? 'COL' : 'METRIC'}
                             </span>
                           )}
-                          <span>{highlightText(item.label, searchQuery)}</span>
+                          <TooltipLabel label={item.label} className="flex-1">
+                            {highlightText(item.label, searchQuery)}
+                          </TooltipLabel>
                         </div>
                       )}
                     />

--- a/components/charts/MetricAccordionItem.tsx
+++ b/components/charts/MetricAccordionItem.tsx
@@ -15,6 +15,7 @@ import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Combobox, highlightText } from '@/components/ui/combobox';
+import { TooltipLabel } from '@/components/charts/types/shared/TooltipLabel';
 import { ColumnTypeIcon } from '@/lib/columnTypeIcons';
 import { X, Loader2, Library, Save, ChevronDown } from 'lucide-react';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
@@ -337,8 +338,10 @@ export function MetricAccordionItem({
               noItemsMessage="No saved metrics yet"
               renderItem={(item, _sel, q) => (
                 <div className="flex flex-col min-w-0">
-                  <span className="truncate">{highlightText(item.label, q)}</span>
-                  <span className="text-xs text-muted-foreground truncate">{item.summary}</span>
+                  <TooltipLabel label={item.label}>{highlightText(item.label, q)}</TooltipLabel>
+                  <TooltipLabel label={item.summary} className="text-xs text-muted-foreground">
+                    {item.summary}
+                  </TooltipLabel>
                 </div>
               )}
             />
@@ -386,7 +389,7 @@ export function MetricAccordionItem({
                     {item.value !== '*' && (
                       <ColumnTypeIcon dataType={item.data_type} className="w-4 h-4" />
                     )}
-                    <span className="truncate">{highlightText(item.label, q)}</span>
+                    <TooltipLabel label={item.label}>{highlightText(item.label, q)}</TooltipLabel>
                   </div>
                 )}
               />

--- a/components/charts/TableDimensionsSelector.tsx
+++ b/components/charts/TableDimensionsSelector.tsx
@@ -7,6 +7,7 @@ import { Switch } from '@/components/ui/switch';
 import { Label } from '@/components/ui/label';
 import { ColumnTypeIcon } from '@/lib/columnTypeIcons';
 import { Combobox, highlightText } from '@/components/ui/combobox';
+import { TooltipLabel } from '@/components/charts/types/shared/TooltipLabel';
 import { ConfirmationDialog } from '@/components/ui/confirmation-dialog';
 import type { ChartDimension } from '@/types/charts';
 import {
@@ -116,9 +117,9 @@ function SortableDimensionItem({
           renderItem={(item, _isSelected, searchQuery) => (
             <div className="flex items-center gap-2 min-w-0">
               <ColumnTypeIcon dataType={item.data_type} className="w-4 h-4 flex-shrink-0" />
-              <span className="truncate" title={`${item.label} (${item.data_type})`}>
+              <TooltipLabel label={`${item.label} (${item.data_type})`}>
                 {highlightText(item.label, searchQuery)}
-              </span>
+              </TooltipLabel>
             </div>
           )}
         />

--- a/components/charts/types/shared/TooltipLabel.tsx
+++ b/components/charts/types/shared/TooltipLabel.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip';
+import { cn } from '@/lib/utils';
+
+interface TooltipLabelProps {
+  /**
+   * The rendered (possibly highlighted/decorated) label content — what's actually shown,
+   * truncated with an ellipsis if it overflows.
+   */
+  children: React.ReactNode;
+  /**
+   * The full, plain-text label to show in the tooltip on hover.
+   */
+  label: string;
+  /**
+   * Extra classes for the truncated span (e.g. width constraints like 'max-w-[120px]').
+   */
+  className?: string;
+  /**
+   * Tooltip position relative to the label. Defaults to 'right', which fits best for
+   * items inside a combobox dropdown list (opens away from the list itself).
+   */
+  side?: 'top' | 'bottom' | 'left' | 'right';
+}
+
+/**
+ * Truncated text + hover tooltip showing the full label. Used inside Combobox `renderItem`
+ * callbacks for chart dropdowns whose options come from the warehouse (column names, dataset
+ * names, etc.) and can be arbitrarily long.
+ *
+ * z-[60] keeps the tooltip above the combobox's own popover panel — both default to z-50, and
+ * the popover mounts first, so without this override the tooltip can render visually behind it.
+ */
+export function TooltipLabel({ children, label, className, side = 'right' }: TooltipLabelProps) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        {/* block, not the span default of inline, so text-overflow ellipsis actually applies */}
+        <span className={cn('block truncate', className)}>{children}</span>
+      </TooltipTrigger>
+      <TooltipContent side={side} className="z-[60]">
+        {label}
+      </TooltipContent>
+    </Tooltip>
+  );
+}


### PR DESCRIPTION
 -DALGO-894: table and pivot_table charts were missing the "Chart Data"
  sub-tab in both new-chart and edit-chart flows; pivot_table now renders
  via ChartPreview instead of DataPreview
- DALGO-1478: dropdowns sourced from warehouse columns (dimensions, filters,
  sort, metrics) can have arbitrarily long names; added TooltipLabel to
  show the full name on hover

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chart Data and Raw Data tabs are now available for all chart types, including table and pivot-table charts.
  * Pivot-table charts now display their chart data in a dedicated preview.
  * Truncated chart configuration labels can now be viewed in full via tooltips, including columns, metrics, filters, and sorting options.

* **UI Improvements**
  * Improved sorting control layout keeps labels readable and badges properly aligned.
  * Tooltips include helpful column details such as names and data types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->