### PR TITLE
fix: prevent duplicate dashboard creation on refresh of dashboard edi…

### DIFF
--- a/app/dashboards/[id]/edit/page.tsx
+++ b/app/dashboards/[id]/edit/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useParams, useRouter } from 'next/navigation';
+import { useParams, useRouter, useSearchParams } from 'next/navigation';
 import { useEffect, useRef, useState } from 'react';
 import { DashboardBuilderV2 } from '@/components/dashboard/dashboard-builder-v2';
 import { useDashboard } from '@/hooks/api/useDashboards';
@@ -14,7 +14,9 @@ import { apiDelete } from '@/lib/api';
 export default function EditDashboardPage() {
   const params = useParams();
   const router = useRouter();
+  const searchParams = useSearchParams();
   const dashboardId = parseInt(params.id as string);
+  const isNewDashboard = searchParams.get('new') === 'true';
 
   // Ref to access dashboard builder cleanup function
   const dashboardBuilderRef = useRef<{ cleanup: () => Promise<void> } | null>(null);
@@ -316,6 +318,7 @@ export default function EditDashboardPage() {
         isLocked: dashboard?.is_locked || false,
         lockedBy: dashboard?.locked_by,
       }}
+      isNewDashboard={isNewDashboard}
       onBack={handleBackNavigation}
       onPreview={handlePreviewMode}
       isNavigating={isNavigating}

--- a/app/dashboards/create/page.tsx
+++ b/app/dashboards/create/page.tsx
@@ -1,46 +1,38 @@
 'use client';
 
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
-import { DashboardBuilderV2 } from '@/components/dashboard/dashboard-builder-v2';
 import { createDashboard } from '@/hooks/api/useDashboards';
 import { toastSuccess, toastError } from '@/lib/toast';
 import { Button } from '@/components/ui/button';
 import { ArrowLeft, Lock } from 'lucide-react';
-import Link from 'next/link';
 import { PERMISSIONS, useRbac } from '@/lib/rbac';
-import { apiDelete } from '@/lib/api';
 import { trackEvent } from '@/lib/analytics';
 import { ANALYTICS_EVENTS } from '@/constants/analytics';
 
 export default function CreateDashboardPage() {
   const router = useRouter();
-  const [dashboardId, setDashboardId] = useState<number | null>(null);
   const [isCreating, setIsCreating] = useState(false);
-  const [dashboardData, setDashboardData] = useState<any>(null);
   const [mounted, setMounted] = useState(false);
-  const [isNavigating, setIsNavigating] = useState(false);
 
   // Get user permissions — the access-denied return lives below, after all hooks,
   // to keep the hook order stable across renders (Rules of Hooks)
   const { hasPermission } = useRbac();
   const canCreateDashboard = hasPermission(PERMISSIONS.CAN_CREATE_DASHBOARDS);
 
-  // Ref to access dashboard builder cleanup function
-  const dashboardBuilderRef = useRef<{ cleanup: () => Promise<void> } | null>(null);
-
   // Ensure component is mounted before running client-side code
   useEffect(() => {
     setMounted(true);
   }, []);
 
-  // Create dashboard immediately after mount — never for users without permission
+  // Create the dashboard once, then hand off to its edit page via the URL.
+  // The URL (not local state) guards against re-creation: a refresh always
+  // remounts this page from a clean slate, so if creation itself set local
+  // state instead of navigating, a refresh would create another dashboard.
   useEffect(() => {
-    if (!mounted || !canCreateDashboard) return;
+    if (!mounted || !canCreateDashboard || isCreating) return;
 
     const initDashboard = async () => {
-      if (isCreating || dashboardId) return;
-
       setIsCreating(true);
       try {
         const dashboard = await createDashboard({
@@ -49,146 +41,18 @@ export default function CreateDashboardPage() {
         });
 
         trackEvent(ANALYTICS_EVENTS.DASHBOARD_CREATED);
-        setDashboardId(dashboard.id);
-        setDashboardData({
-          title: dashboard.title,
-          grid_columns: dashboard.grid_columns || 12,
-          tabs: dashboard.tabs || [],
-        });
-
         toastSuccess.created('Dashboard');
+        router.replace(`/dashboards/${dashboard.id}/edit?new=true`);
       } catch (error: any) {
         console.error('Failed to create dashboard:', error);
         toastError.create(error, 'dashboard');
-        // Redirect back to dashboard list on error
         router.push('/dashboards');
-      } finally {
         setIsCreating(false);
       }
     };
 
     initDashboard();
-  }, [mounted, canCreateDashboard, isCreating, dashboardId, router]);
-
-  // Direct API call to unlock dashboard - bypasses the full cleanup chain
-  const emergencyUnlock = async () => {
-    if (dashboardId) {
-      try {
-        await apiDelete(`/api/dashboards/${dashboardId}/lock/`);
-      } catch (error) {
-        console.error(`Failed to unlock dashboard ${dashboardId}:`, error);
-      }
-    }
-  };
-
-  // Clean up on route change or component unmount
-  useEffect(() => {
-    // Function to handle cleanup synchronously for critical scenarios
-    const handleSyncCleanup = () => {
-      // First try emergency unlock (direct API call)
-      emergencyUnlock();
-
-      // Then also try the full cleanup chain as backup
-      if (dashboardBuilderRef.current?.cleanup) {
-        // Fire and forget - don't wait for async completion during sync cleanup
-        dashboardBuilderRef.current.cleanup().catch((error) => {
-          console.error('Error during dashboard cleanup:', error);
-        });
-      }
-    };
-
-    // Function to handle cleanup asynchronously for normal scenarios
-    const handleAsyncCleanup = async () => {
-      if (dashboardBuilderRef.current?.cleanup) {
-        try {
-          await dashboardBuilderRef.current.cleanup();
-        } catch (error) {
-          console.error('Error during dashboard cleanup:', error);
-        }
-      }
-    };
-
-    // Handle browser navigation (back/forward buttons, direct navigation)
-    const handleBeforeUnload = (e: BeforeUnloadEvent) => {
-      handleSyncCleanup();
-    };
-
-    // Handle popstate for browser back/forward
-    const handlePopState = () => {
-      handleSyncCleanup();
-    };
-
-    // Handle page visibility change (when tab becomes hidden/inactive)
-    const handleVisibilityChange = () => {
-      if (document.hidden) {
-        handleSyncCleanup();
-      }
-    };
-
-    // Intercept link clicks to dashboard-related routes
-    const handleLinkClick = (e: Event) => {
-      const target = e.target as HTMLElement;
-      const link = target.closest('a[href]') as HTMLAnchorElement;
-
-      if (link && link.href) {
-        const url = new URL(link.href, window.location.origin);
-        // Check if navigating away from current create page
-        if (url.pathname !== window.location.pathname) {
-          handleSyncCleanup();
-        }
-      }
-    };
-
-    // Add event listeners
-    window.addEventListener('beforeunload', handleBeforeUnload);
-    window.addEventListener('popstate', handlePopState);
-    document.addEventListener('visibilitychange', handleVisibilityChange);
-    document.addEventListener('click', handleLinkClick, true); // Use capture phase
-
-    // Cleanup function that runs when component unmounts
-    // This is for Next.js router navigation
-    return () => {
-      // Use sync cleanup during unmount to avoid race conditions
-      handleSyncCleanup();
-
-      // Clean up event listeners
-      window.removeEventListener('beforeunload', handleBeforeUnload);
-      window.removeEventListener('popstate', handlePopState);
-      document.removeEventListener('visibilitychange', handleVisibilityChange);
-      document.removeEventListener('click', handleLinkClick, true);
-    };
-  }, [dashboardId]);
-
-  // Handle navigation back to dashboard list
-  const handleBackNavigation = async () => {
-    // Call cleanup function if available
-    if (dashboardBuilderRef.current?.cleanup) {
-      await dashboardBuilderRef.current.cleanup();
-    }
-
-    // Navigate to dashboard list
-    router.push('/dashboards');
-  };
-
-  // Handle navigation to preview mode
-  const handlePreviewMode = async () => {
-    if (!dashboardId) return;
-
-    setIsNavigating(true);
-
-    try {
-      // Call cleanup function if available (this will save changes first)
-      if (dashboardBuilderRef.current?.cleanup) {
-        await dashboardBuilderRef.current.cleanup();
-      }
-
-      // Navigate to preview mode
-      router.push(`/dashboards/${dashboardId}`);
-    } catch (error) {
-      console.error('Error navigating to preview mode:', error);
-      setIsNavigating(false);
-    }
-  };
+  }, [mounted, canCreateDashboard, isCreating, router]);
 
   // Check if user has create permissions (after all hooks — Rules of Hooks)
   if (!canCreateDashboard) {
@@ -211,38 +75,12 @@ export default function CreateDashboardPage() {
     );
   }
 
-  // Show loading state during SSR and while creating
-  if (!mounted || isCreating) {
-    return (
-      <div className="h-screen flex items-center justify-center">
-        <div className="text-center">
-          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-gray-900 mx-auto mb-4"></div>
-          <p className="text-gray-600">Creating dashboard...</p>
-        </div>
-      </div>
-    );
-  }
-
-  if (!dashboardId || !dashboardData) {
-    return (
-      <div className="h-screen flex items-center justify-center">
-        <div className="text-center">
-          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-gray-900 mx-auto mb-4"></div>
-          <p className="text-gray-600">Initializing...</p>
-        </div>
-      </div>
-    );
-  }
-
   return (
-    <DashboardBuilderV2
-      ref={dashboardBuilderRef}
-      dashboardId={dashboardId}
-      initialData={dashboardData}
-      isNewDashboard={true}
-      onBack={handleBackNavigation}
-      onPreview={handlePreviewMode}
-      isNavigating={isNavigating}
-    />
+    <div className="h-screen flex items-center justify-center">
+      <div className="text-center">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-gray-900 mx-auto mb-4"></div>
+        <p className="text-gray-600">Creating dashboard...</p>
+      </div>
+    </div>
   );
 }

--- a/app/dashboards/create/page.tsx
+++ b/app/dashboards/create/page.tsx
@@ -13,24 +13,18 @@ import { ANALYTICS_EVENTS } from '@/constants/analytics';
 export default function CreateDashboardPage() {
   const router = useRouter();
   const [isCreating, setIsCreating] = useState(false);
-  const [mounted, setMounted] = useState(false);
 
   // Get user permissions — the access-denied return lives below, after all hooks,
   // to keep the hook order stable across renders (Rules of Hooks)
   const { hasPermission } = useRbac();
   const canCreateDashboard = hasPermission(PERMISSIONS.CAN_CREATE_DASHBOARDS);
 
-  // Ensure component is mounted before running client-side code
-  useEffect(() => {
-    setMounted(true);
-  }, []);
-
   // Create the dashboard once, then hand off to its edit page via the URL.
   // The URL (not local state) guards against re-creation: a refresh always
   // remounts this page from a clean slate, so if creation itself set local
   // state instead of navigating, a refresh would create another dashboard.
   useEffect(() => {
-    if (!mounted || !canCreateDashboard || isCreating) return;
+    if (!canCreateDashboard || isCreating) return;
 
     const initDashboard = async () => {
       setIsCreating(true);
@@ -47,12 +41,11 @@ export default function CreateDashboardPage() {
         console.error('Failed to create dashboard:', error);
         toastError.create(error, 'dashboard');
         router.push('/dashboards');
-        setIsCreating(false);
       }
     };
 
     initDashboard();
-  }, [mounted, canCreateDashboard, isCreating, router]);
+  }, [canCreateDashboard, isCreating, router]);
 
   // Check if user has create permissions (after all hooks — Rules of Hooks)
   if (!canCreateDashboard) {


### PR DESCRIPTION
 prevent duplicate dashboard creation on refresh of dashboard editor page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Dashboard creation now automatically opens the new dashboard in edit mode.
  - New dashboards are clearly identified during the editing experience.

- **Bug Fixes**
  - Improved dashboard creation flow with more reliable navigation and error handling.
  - Prevented duplicate dashboard creation during page initialization.
  - Simplified the creation experience by displaying a clear loading state while the dashboard is being prepared.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->