### PR TITLE
feature/gsheets-managed-service-account

### DIFF
--- a/components/ingest/sources/SourceConfigFields.tsx
+++ b/components/ingest/sources/SourceConfigFields.tsx
@@ -17,6 +17,8 @@ interface SourceConfigFieldsProps {
   mode: 'create' | 'edit';
   /** Google-only OAuth wiring; forwarded to the custom form. Undefined otherwise. */
   oauth?: CustomSourceOAuth;
+  /** Google-only. See `CustomSourceFormProps.onAuthSatisfiedChange`. */
+  onAuthSatisfiedChange?: (satisfied: boolean) => void;
   /** Host-owned source-name field, rendered at the top of the custom form's left
    *  column so it lines up with the other fields (not full-width above the grid). */
   nameField?: ReactNode;
@@ -45,6 +47,7 @@ export function SourceConfigFields({
   disabled,
   mode,
   oauth,
+  onAuthSatisfiedChange,
   nameField,
   setupLogs,
   logsTestId,
@@ -63,6 +66,7 @@ export function SourceConfigFields({
             disabled={disabled}
             mode={mode}
             oauth={oauth}
+            onAuthSatisfiedChange={onAuthSatisfiedChange}
           />
         </div>
       ) : parsedSpec ? (

--- a/components/ingest/sources/SourceForm.tsx
+++ b/components/ingest/sources/SourceForm.tsx
@@ -220,6 +220,7 @@ export function SourceForm({ open, onClose, onSuccess, sourceId }: SourceFormPro
       await updateSource(sourceId, {
         name: sourceName,
         sourceDefId: selectedDefId!,
+        sourceName: selectedName,
         config,
         sourceId,
       });
@@ -339,7 +340,13 @@ export function SourceForm({ open, onClose, onSuccess, sourceId }: SourceFormPro
     const config = buildConfig();
     setSetupLogs([]);
     setLoading(true);
-    sendOrQueue({ name: sourceName, sourceDefId: selectedDefId, config, sourceId });
+    sendOrQueue({
+      name: sourceName,
+      sourceDefId: selectedDefId,
+      sourceName: selectedName,
+      config,
+      sourceId,
+    });
   }, [
     validateHostFields,
     parsedSpec,

--- a/components/ingest/sources/SourceForm.tsx
+++ b/components/ingest/sources/SourceForm.tsx
@@ -220,7 +220,7 @@ export function SourceForm({ open, onClose, onSuccess, sourceId }: SourceFormPro
       await updateSource(sourceId, {
         name: sourceName,
         sourceDefId: selectedDefId!,
-        sourceName: selectedName,
+        sourceDefName: selectedName,
         config,
         sourceId,
       });
@@ -357,7 +357,7 @@ export function SourceForm({ open, onClose, onSuccess, sourceId }: SourceFormPro
     sendOrQueue({
       name: sourceName,
       sourceDefId: selectedDefId,
-      sourceName: selectedName,
+      sourceDefName: selectedName,
       config,
       sourceId,
     });

--- a/components/ingest/sources/SourceForm.tsx
+++ b/components/ingest/sources/SourceForm.tsx
@@ -324,6 +324,15 @@ export function SourceForm({ open, onClose, onSuccess, sourceId }: SourceFormPro
     onSuccess,
   ]);
 
+  // MANAGED-SA: the form reports whether auth is satisfied, because "use Dalgo's key" leaves the
+  // credentials empty on purpose — clearing the key field and saving without choosing anything
+  // would otherwise hand out Dalgo's key silently.
+  const [authSatisfied, setAuthSatisfied] = useState(true);
+  const [authError, setAuthError] = useState<string | null>(null);
+  useEffect(() => {
+    if (authSatisfied) setAuthError(null);
+  }, [authSatisfied]);
+
   // Single submit: a fresh OAuth ref is redeemed directly; otherwise the config is
   // tested over the WebSocket and saved on success.
   const onSubmit = useCallback(() => {
@@ -331,6 +340,11 @@ export function SourceForm({ open, onClose, onSuccess, sourceId }: SourceFormPro
     // The spec is still in flight — nothing to build a config from yet, so swallow
     // the submit rather than sending a partial payload.
     if (!parsedSpec) return;
+
+    if (isGoogleSheetsCustom && !authSatisfied) {
+      setAuthError('Paste a service-account key, or tick “Use Dalgo’s service account”');
+      return;
+    }
 
     if (oauthRef) {
       handleUpdateOAuthSource();
@@ -353,6 +367,8 @@ export function SourceForm({ open, onClose, onSuccess, sourceId }: SourceFormPro
     sourceName,
     selectedDefId,
     oauthRef,
+    isGoogleSheetsCustom,
+    authSatisfied,
     handleUpdateOAuthSource,
     buildConfig,
     sourceId,
@@ -452,6 +468,7 @@ export function SourceForm({ open, onClose, onSuccess, sourceId }: SourceFormPro
                 setValue={setValue}
                 disabled={loading}
                 mode="edit"
+                onAuthSatisfiedChange={isGoogleSheetsCustom ? setAuthSatisfied : undefined}
                 oauth={
                   isGoogleSheetsCustom
                     ? ({
@@ -469,6 +486,7 @@ export function SourceForm({ open, onClose, onSuccess, sourceId }: SourceFormPro
                             : 'Authenticate with Google',
                         lockWhenConnected: false,
                         onClick: handleConnectGoogle,
+                        error: authError ?? undefined,
                       } satisfies CustomSourceOAuth)
                     : undefined
                 }

--- a/components/ingest/sources/custom/GoogleSheetsForm.tsx
+++ b/components/ingest/sources/custom/GoogleSheetsForm.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Check, Loader2 } from 'lucide-react';
 import { useWatch } from 'react-hook-form';
 import { renderField } from '@/components/connectors/ConnectorConfigForm';
@@ -13,6 +13,7 @@ import {
 import { Label } from '@/components/ui/label';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import type { FieldNode } from '@/components/connectors/types';
+import { useManagedServiceAccount } from '@/hooks/api/useSources';
 import {
   GSHEETS_KEY_CREDENTIALS,
   GSHEETS_AUTH_DISCRIMINATOR,
@@ -21,6 +22,7 @@ import {
   GSHEETS_OAUTH_AUTH_TYPE,
   GSHEETS_SERVICE_AUTH_TYPE,
 } from './constants';
+import { GsheetsAuthChoice } from './GsheetsAuthChoice';
 import { partitionFields } from './partition-fields';
 import type { CustomSourceFormProps } from './types';
 
@@ -63,13 +65,18 @@ function keyOf(field: FieldNode): string {
  * added in a future Google Sheets connector version shows up without a code change.
  * The only field held back is the `credentials` oneOf, which the sign-in button and
  * the service-account field below stand in for.
+ *
+ * MANAGED-SA bridge: with a deployment key configured, the sign-in button is replaced by a
+ * two-way choice — Dalgo's key or your own. Delete with the bridge.
  */
 export function GoogleSheetsForm({
   parsedSpec,
   control,
   setValue,
   disabled,
+  mode,
   oauth,
+  onAuthSatisfiedChange,
 }: CustomSourceFormProps) {
   // Matched on the discriminator first (the spec's own shape) and on the well-known key
   // as a fallback, so a renamed discriminator still can't leak raw client_id/secret
@@ -129,6 +136,36 @@ export function GoogleSheetsForm({
 
   const connected = !!oauth?.connected;
 
+  // MANAGED-SA bridge. Sign-in stays hidden until our OAuth client is verified, so with a key
+  // configured this form offers only the two service-account options. No carve-out for a
+  // connected OAuth source — none can exist, sign-in was never released. Unset the key and the
+  // OAuth code below takes over again, untouched.
+  const { managed } = useManagedServiceAccount(true);
+  const managedEmail = managed?.email ?? null;
+  const useManagedChoice = !!managedEmail;
+  // Opting into Dalgo's key. Never seeded from the saved config — which key a source uses is
+  // not recorded, and Airbyte returns the stored one masked, so on edit this stays false and the
+  // checkbox is simply not offered while a key is present.
+  const [useManagedKey, setUseManagedKey] = useState(false);
+
+  // A key typed before ticking is parked here, so unticking gives it back rather than eating it.
+  const parkedKey = useRef<string | undefined>(undefined);
+  const handleUseManagedKeyChange = useCallback(
+    (next: boolean) => {
+      if (next) {
+        // The backend fills the slot precisely because it arrives empty, so clear it for real —
+        // the asterisks the user sees are a stand-in that never enters the form.
+        parkedKey.current = serviceValue;
+        if (serviceValue) setValue(servicePath, undefined);
+      } else if (parkedKey.current) {
+        setValue(servicePath, parkedKey.current);
+        parkedKey.current = undefined;
+      }
+      setUseManagedKey(next);
+    },
+    [serviceValue, servicePath, setValue]
+  );
+
   // Deliberate escape hatch off an already-connected OAuth source: the service
   // field stays disabled while connected (see serviceDisabled below), so typing
   // alone can't switch away — the discriminator effect just fights it, since
@@ -145,6 +182,17 @@ export function GoogleSheetsForm({
   // fields so the config only ever matches one oneOf branch at a time.
   useEffect(() => {
     if (!discriminatorPath) return;
+
+    // MANAGED-SA: both options are the Service branch. Managed sends the discriminator and no
+    // key — the backend reads that empty slot as "use ours".
+    if (useManagedChoice) {
+      for (const field of clientBranchFields) {
+        setValue(field.path.join('.'), undefined);
+      }
+      setValue(discriminatorPath, GSHEETS_SERVICE_AUTH_TYPE);
+      return;
+    }
+
     if (effectiveConnected) {
       if (serviceValue) setValue(servicePath, undefined);
       setValue(discriminatorPath, GSHEETS_OAUTH_AUTH_TYPE);
@@ -166,7 +214,19 @@ export function GoogleSheetsForm({
     discriminatorPath,
     clientBranchFields,
     setValue,
+    useManagedChoice,
   ]);
+
+  // The host can't infer this: "use Dalgo's key" leaves credentials empty on purpose, so an
+  // empty config is a valid choice rather than a missing one.
+  useEffect(() => {
+    if (!onAuthSatisfiedChange) return;
+    if (useManagedChoice) {
+      onAuthSatisfiedChange(useManagedKey || serviceProvided);
+      return;
+    }
+    onAuthSatisfiedChange(connected || serviceProvided);
+  }, [onAuthSatisfiedChange, useManagedChoice, useManagedKey, serviceProvided, connected]);
 
   const serviceDisabled = disabled || effectiveConnected;
 
@@ -192,89 +252,107 @@ export function GoogleSheetsForm({
     <div className="space-y-4" data-testid="google-sheets-form">
       {primary.map((field) => renderField(field, control, setValue, disabled))}
 
-      {/* Google OAuth button (or static confirmation once connected in create). */}
-      {oauth && (
-        <div className="space-y-2">
-          <Label>
-            Authentication <span className="text-destructive">*</span>
-          </Label>
-          {connected && oauth.lockWhenConnected ? (
-            <div
-              data-testid="gsheets-oauth-connected"
-              className="flex w-full items-center gap-3 rounded-md border border-green-600/40 bg-green-600/5 px-4 py-3 text-sm dark:border-green-400/40"
-            >
-              <Check className="h-5 w-5 flex-shrink-0 text-green-600 dark:text-green-400" />
-              <span className="font-medium text-green-600 dark:text-green-400">
-                {oauth.buttonLabel}
-              </span>
-            </div>
-          ) : oauthBlocked ? (
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <span className="block">
-                  <button
-                    type="button"
-                    data-testid="gsheets-oauth-connect-btn"
-                    disabled
-                    className="flex w-full cursor-not-allowed items-center gap-3 rounded-md border px-4 py-3 text-left text-sm opacity-60"
-                  >
-                    <GoogleIcon className="h-5 w-5 flex-shrink-0" />
-                    <span className="font-medium">Authenticate with Google</span>
-                  </button>
-                </span>
-              </TooltipTrigger>
-              <TooltipContent data-testid="gsheets-oauth-blocked-tooltip">
-                Remove the service-account key below to authenticate with Google instead.
-              </TooltipContent>
-            </Tooltip>
-          ) : (
-            <button
-              type="button"
-              data-testid="gsheets-oauth-connect-btn"
-              onClick={oauth.onClick}
-              disabled={disabled || oauth.busy}
-              className="flex w-full cursor-pointer items-center gap-3 rounded-md border px-4 py-3 text-left text-sm transition-colors hover:bg-muted/40 disabled:cursor-not-allowed disabled:opacity-60"
-            >
-              {connected ? (
-                <Check className="h-5 w-5 flex-shrink-0 text-green-600 dark:text-green-400" />
-              ) : (
-                <GoogleIcon className="h-5 w-5 flex-shrink-0" />
-              )}
-              <span
-                className={
-                  connected ? 'font-medium text-green-600 dark:text-green-400' : 'font-medium'
-                }
+      {/* MANAGED-SA: with a key configured, the two options replace sign-in entirely. */}
+      {useManagedChoice && managedEmail ? (
+        <GsheetsAuthChoice
+          email={managedEmail}
+          useManagedKey={useManagedKey}
+          onUseManagedKeyChange={handleUseManagedKeyChange}
+          hasKey={serviceProvided}
+          mode={mode}
+          disabled={disabled}
+          error={oauth?.error}
+          keyField={
+            serviceFieldForRender
+              ? renderField(serviceFieldForRender, control, setValue, disabled)
+              : null
+          }
+          keyFieldLabel={serviceField?.title ?? 'Service Account Information.'}
+        />
+      ) : (
+        oauth && (
+          <div className="space-y-2">
+            <Label>
+              Authentication <span className="text-destructive">*</span>
+            </Label>
+            {connected && oauth.lockWhenConnected ? (
+              <div
+                data-testid="gsheets-oauth-connected"
+                className="flex w-full items-center gap-3 rounded-md border border-green-600/40 bg-green-600/5 px-4 py-3 text-sm dark:border-green-400/40"
               >
-                {oauth.buttonLabel}
-              </span>
-              {oauth.busy && <Loader2 className="ml-auto h-4 w-4 animate-spin" />}
-            </button>
-          )}
-          {connected && !serviceUnlocked && (
-            <button
-              type="button"
-              onClick={() => setServiceUnlocked(true)}
-              data-testid="gsheets-use-service-key-btn"
-              className="text-xs text-muted-foreground underline-offset-2 hover:underline"
-            >
-              Use a service-account key instead
-            </button>
-          )}
-          {serviceUnlocked && (
-            <p className="text-xs text-muted-foreground" data-testid="gsheets-unlock-note">
-              Paste a service-account key below — saving will replace your Google connection with
-              it.
-            </p>
-          )}
-          {oauth.error && (
-            <p className="text-xs text-destructive mt-1" data-testid="gsheets-auth-error">
-              {oauth.error}
-            </p>
-          )}
-        </div>
+                <Check className="h-5 w-5 flex-shrink-0 text-green-600 dark:text-green-400" />
+                <span className="font-medium text-green-600 dark:text-green-400">
+                  {oauth.buttonLabel}
+                </span>
+              </div>
+            ) : oauthBlocked ? (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span className="block">
+                    <button
+                      type="button"
+                      data-testid="gsheets-oauth-connect-btn"
+                      disabled
+                      className="flex w-full cursor-not-allowed items-center gap-3 rounded-md border px-4 py-3 text-left text-sm opacity-60"
+                    >
+                      <GoogleIcon className="h-5 w-5 flex-shrink-0" />
+                      <span className="font-medium">Authenticate with Google</span>
+                    </button>
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent data-testid="gsheets-oauth-blocked-tooltip">
+                  Remove the service-account key below to authenticate with Google instead.
+                </TooltipContent>
+              </Tooltip>
+            ) : (
+              <button
+                type="button"
+                data-testid="gsheets-oauth-connect-btn"
+                onClick={oauth.onClick}
+                disabled={disabled || oauth.busy}
+                className="flex w-full cursor-pointer items-center gap-3 rounded-md border px-4 py-3 text-left text-sm transition-colors hover:bg-muted/40 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {connected ? (
+                  <Check className="h-5 w-5 flex-shrink-0 text-green-600 dark:text-green-400" />
+                ) : (
+                  <GoogleIcon className="h-5 w-5 flex-shrink-0" />
+                )}
+                <span
+                  className={
+                    connected ? 'font-medium text-green-600 dark:text-green-400' : 'font-medium'
+                  }
+                >
+                  {oauth.buttonLabel}
+                </span>
+                {oauth.busy && <Loader2 className="ml-auto h-4 w-4 animate-spin" />}
+              </button>
+            )}
+            {connected && !serviceUnlocked && (
+              <button
+                type="button"
+                onClick={() => setServiceUnlocked(true)}
+                data-testid="gsheets-use-service-key-btn"
+                className="text-xs text-muted-foreground underline-offset-2 hover:underline"
+              >
+                Use a service-account key instead
+              </button>
+            )}
+            {serviceUnlocked && (
+              <p className="text-xs text-muted-foreground" data-testid="gsheets-unlock-note">
+                Paste a service-account key below — saving will replace your Google connection with
+                it.
+              </p>
+            )}
+            {oauth.error && (
+              <p className="text-xs text-destructive mt-1" data-testid="gsheets-auth-error">
+                {oauth.error}
+              </p>
+            )}
+          </div>
+        )
       )}
 
-      {(advanced.length > 0 || serviceField) && (
+      {(advanced.length > 0 || (serviceField && !useManagedChoice)) && (
         <Accordion
           type="single"
           collapsible
@@ -291,7 +369,8 @@ export function GoogleSheetsForm({
             </AccordionTrigger>
             <AccordionContent className="space-y-4">
               {advanced.map((field) => renderField(field, control, setValue, disabled))}
-              {serviceField && (
+              {/* MANAGED-SA: on the managed path this renders under the "own key" radio. */}
+              {serviceField && !useManagedChoice && (
                 <div
                   className={effectiveConnected ? 'opacity-60' : undefined}
                   data-testid="gsheets-service-field"

--- a/components/ingest/sources/custom/GoogleSheetsForm.tsx
+++ b/components/ingest/sources/custom/GoogleSheetsForm.tsx
@@ -166,6 +166,20 @@ export function GoogleSheetsForm({
     [serviceValue, servicePath, setValue]
   );
 
+  // A NEW source defaults to Dalgo's key — it's the only route most trial users can finish
+  // without going and minting a service account first. Applied in an effect rather than as the
+  // initial state because the deployment key's email arrives async, so the first render can't
+  // know the option exists. Runs once, and never on edit: there, a saved key is present and the
+  // checkbox isn't even offered (see GsheetsAuthChoice). A key already typed wins too — that's
+  // the user having chosen their own, so don't clear it out from under them.
+  const managedDefaultAppliedRef = useRef(false);
+  useEffect(() => {
+    if (mode !== 'create' || !useManagedChoice || managedDefaultAppliedRef.current) return;
+    managedDefaultAppliedRef.current = true;
+    if (serviceProvided) return;
+    setUseManagedKey(true);
+  }, [mode, useManagedChoice, serviceProvided]);
+
   // Deliberate escape hatch off an already-connected OAuth source: the service
   // field stays disabled while connected (see serviceDisabled below), so typing
   // alone can't switch away — the discriminator effect just fights it, since

--- a/components/ingest/sources/custom/GsheetsAuthChoice.tsx
+++ b/components/ingest/sources/custom/GsheetsAuthChoice.tsx
@@ -55,14 +55,28 @@ function EmailChip({ email }: { email: string }) {
   );
 }
 
-/** The four steps that grant the service account access. `lead` sets the framing. */
-function ShareSteps({ email, lead, testId }: { email: string; lead: ReactNode; testId: string }) {
+/**
+ * The four steps that grant the service account access. `lead` sets the framing; `footer` is for
+ * anything that only makes sense once the steps have been read (e.g. how to switch key instead).
+ */
+function ShareSteps({
+  email,
+  lead,
+  testId,
+  footer,
+}: {
+  email: string;
+  lead: ReactNode;
+  testId: string;
+  footer?: ReactNode;
+}) {
   return (
     <div
       className="space-y-3 rounded-md border border-primary/40 bg-primary/5 p-4"
       data-testid={testId}
     >
-      <p className="text-sm">{lead}</p>
+      {/* A div, not a <p>: the edit-mode lead is a short block with its own list. */}
+      <div className="space-y-2 text-sm">{lead}</div>
       <EmailChip email={email} />
       <ol className="list-decimal space-y-1 pl-5 text-sm text-muted-foreground">
         <li>Open your spreadsheet in Google Sheets</li>
@@ -72,6 +86,7 @@ function ShareSteps({ email, lead, testId }: { email: string; lead: ReactNode; t
         <li>Paste the address above and set the role to Viewer</li>
         <li>Untick &ldquo;Notify people&rdquo;, then click Share</li>
       </ol>
+      {footer && <div className="text-sm">{footer}</div>}
     </div>
   );
 }
@@ -141,10 +156,11 @@ export function GsheetsAuthChoice({
             <Label htmlFor="gsheets-use-managed" className="cursor-pointer font-medium">
               Use Dalgo&apos;s service account
             </Label>
+            {/* The choice only. What sharing involves, and how far the access reaches, is stated
+                once — in the panel below, next to the address it applies to. */}
             <p className="text-sm text-muted-foreground">
-              Recommended if you don&apos;t have your own service-account key. Instead of pasting
-              one, you share your spreadsheet with Dalgo&apos;s address — read-only, and only the
-              sheets you share.
+              Quickest way to get your sheet set up. Untick to use your own service-account key
+              instead.
             </p>
           </div>
         </div>
@@ -164,10 +180,24 @@ export function GsheetsAuthChoice({
           testId="gsheets-saved-key-note"
           lead={
             <>
-              <span className="font-medium">If this source uses Dalgo&apos;s service account</span>,
-              the address below needs Viewer access on the spreadsheet — do these steps too. If you
-              are using your own key, share the sheet with your own account&apos;s address instead.
-              To switch, clear the field above.
+              <p className="font-medium text-foreground">
+                This source already has a service-account key saved.
+              </p>
+              <p>
+                If you are using Dalgo&apos;s service account rather than your own key, share your
+                spreadsheet with this address:
+              </p>
+            </>
+          }
+          // After the steps, not before them: it's the alternative to doing them.
+          // The field is named rather than called "the field above" — on a form this long,
+          // "above" isn't obvious.
+          footer={
+            <>
+              To change how this source authenticates, clear the{' '}
+              <span className="font-medium text-foreground">Service Account Information</span> field
+              above — the &ldquo;Use Dalgo&apos;s service account&rdquo; choice comes back, and you
+              can either tick it or paste a different key.
             </>
           }
         />

--- a/components/ingest/sources/custom/GsheetsAuthChoice.tsx
+++ b/components/ingest/sources/custom/GsheetsAuthChoice.tsx
@@ -1,0 +1,183 @@
+'use client';
+
+import { useCallback, useState, type ReactNode } from 'react';
+import { Check, Copy } from 'lucide-react';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+// How long the copy button shows its "copied" tick before reverting.
+const COPIED_RESET_MS = 2000;
+
+// Stand-in shown in the key field once the managed option is ticked. Display only — it is never
+// written to the form, because the backend fills the slot precisely because it arrives empty.
+const MANAGED_KEY_PLACEHOLDER = '*'.repeat(48);
+
+interface GsheetsAuthChoiceProps {
+  /** `client_email` of the Dalgo-managed service account. */
+  email: string;
+  useManagedKey: boolean;
+  onUseManagedKeyChange: (next: boolean) => void;
+  /** Whether the form currently holds a service-account key. */
+  hasKey: boolean;
+  mode: 'create' | 'edit';
+  disabled?: boolean;
+  error?: string;
+  /** The spec-driven service-account JSON field, and its label (mirrored by the stand-in). */
+  keyField: ReactNode;
+  keyFieldLabel: string;
+}
+
+/** The address to share the spreadsheet with, as a click-to-copy chip. */
+function EmailChip({ email }: { email: string }) {
+  const [copied, setCopied] = useState(false);
+  const handleCopy = useCallback(() => {
+    navigator.clipboard.writeText(email);
+    setCopied(true);
+    setTimeout(() => setCopied(false), COPIED_RESET_MS);
+  }, [email]);
+
+  return (
+    <button
+      type="button"
+      onClick={handleCopy}
+      data-testid="gsheets-managed-email"
+      title="Click to copy"
+      className="inline-flex max-w-full items-center gap-2 rounded-md border bg-background px-3 py-2 text-sm font-mono transition-colors hover:bg-muted cursor-pointer"
+    >
+      <span className="truncate">{email}</span>
+      {copied ? (
+        <Check className="h-3.5 w-3.5 flex-shrink-0 text-primary" />
+      ) : (
+        <Copy className="h-3.5 w-3.5 flex-shrink-0 text-muted-foreground" />
+      )}
+    </button>
+  );
+}
+
+/** The four steps that grant the service account access. `lead` sets the framing. */
+function ShareSteps({ email, lead, testId }: { email: string; lead: ReactNode; testId: string }) {
+  return (
+    <div
+      className="space-y-3 rounded-md border border-primary/40 bg-primary/5 p-4"
+      data-testid={testId}
+    >
+      <p className="text-sm">{lead}</p>
+      <EmailChip email={email} />
+      <ol className="list-decimal space-y-1 pl-5 text-sm text-muted-foreground">
+        <li>Open your spreadsheet in Google Sheets</li>
+        <li>
+          Click <span className="font-medium text-foreground">Share</span> (top right)
+        </li>
+        <li>Paste the address above and set the role to Viewer</li>
+        <li>Untick &ldquo;Notify people&rdquo;, then click Share</li>
+      </ol>
+    </div>
+  );
+}
+
+/**
+ * MANAGED-SA bridge — Google Sheets auth while OAuth verification is pending. The key field is
+ * always visible; a checkbox under it opts into Dalgo's key instead of your own.
+ *
+ * Which key a saved source uses is NOT recorded anywhere: both options store a
+ * `service_account_info` that Airbyte returns masked, so on edit this cannot tell them apart. It
+ * therefore drops the checkbox while a saved key is present and states the sharing requirement
+ * conditionally instead of guessing. Clearing the field brings the choice back.
+ *
+ * Delete with the bridge.
+ */
+export function GsheetsAuthChoice({
+  email,
+  useManagedKey,
+  onUseManagedKeyChange,
+  hasKey,
+  mode,
+  disabled,
+  error,
+  keyField,
+  keyFieldLabel,
+}: GsheetsAuthChoiceProps) {
+  // Edit keeps the checkbox out of sight while a key is saved — offering it there would imply we
+  // know whose key it is. Create always shows it.
+  const showCheckbox = mode === 'create' || !hasKey;
+  // The untouched saved key on an edit: say what sharing it needs without claiming which key.
+  const showSavedKeyNote = mode === 'edit' && hasKey && !useManagedKey;
+
+  return (
+    <div className="space-y-3" data-testid="gsheets-auth-choice">
+      <Label>
+        Authentication <span className="text-destructive">*</span>
+      </Label>
+
+      {/* Ticked: the field keeps its place but shows a stand-in, so it reads as "already handled"
+          rather than as an empty required input. */}
+      {useManagedKey ? (
+        <div data-testid="gsheets-managed-placeholder">
+          <Label className="mb-1.5 block text-base font-medium">{keyFieldLabel}</Label>
+          <Input
+            value={MANAGED_KEY_PLACEHOLDER}
+            readOnly
+            disabled
+            aria-label={keyFieldLabel}
+            className="font-mono"
+          />
+        </div>
+      ) : (
+        <div data-testid="gsheets-key-field">{keyField}</div>
+      )}
+
+      {showCheckbox && (
+        <div className="flex items-start gap-3">
+          <Checkbox
+            id="gsheets-use-managed"
+            checked={useManagedKey}
+            onCheckedChange={(next) => onUseManagedKeyChange(next === true)}
+            disabled={disabled}
+            data-testid="gsheets-use-managed-checkbox"
+            className="mt-0.5"
+          />
+          <div className="space-y-1">
+            <Label htmlFor="gsheets-use-managed" className="cursor-pointer font-medium">
+              Use Dalgo&apos;s service account
+            </Label>
+            <p className="text-sm text-muted-foreground">
+              Recommended if you don&apos;t have your own service-account key. Instead of pasting
+              one, you share your spreadsheet with Dalgo&apos;s address — read-only, and only the
+              sheets you share.
+            </p>
+          </div>
+        </div>
+      )}
+
+      {useManagedKey && (
+        <ShareSteps
+          email={email}
+          testId="gsheets-managed-steps"
+          lead="Share your spreadsheet with this address before saving — Dalgo can then read that sheet, and nothing else in your Drive."
+        />
+      )}
+
+      {showSavedKeyNote && (
+        <ShareSteps
+          email={email}
+          testId="gsheets-saved-key-note"
+          lead={
+            <>
+              <span className="font-medium">If this source uses Dalgo&apos;s service account</span>,
+              the address below needs Viewer access on the spreadsheet — do these steps too. If you
+              are using your own key, share the sheet with your own account&apos;s address instead.
+              To switch, clear the field above.
+            </>
+          }
+        />
+      )}
+
+      {error && (
+        <p className="text-xs text-destructive" data-testid="gsheets-auth-error">
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/components/ingest/sources/custom/__tests__/google-sheets-form.test.tsx
+++ b/components/ingest/sources/custom/__tests__/google-sheets-form.test.tsx
@@ -238,19 +238,29 @@ describe('GoogleSheetsForm', () => {
       mockManaged = { email: MANAGED_EMAIL };
     });
 
-    it('replaces Google sign-in with the key field plus a checkbox under it', () => {
+    it('replaces Google sign-in with the choice, ticked, and the key stand-in', () => {
       render(<Harness />);
 
       expect(screen.getByTestId('gsheets-auth-choice')).toBeInTheDocument();
-      expect(screen.getByTestId('gsheets-key-field')).toBeInTheDocument();
-      expect(screen.getByTestId('gsheets-use-managed-checkbox')).toBeInTheDocument();
+      expect(screen.getByTestId('gsheets-use-managed-checkbox')).toBeChecked();
+      // Ticked by default on create, so the field shows its stand-in rather than an empty input.
+      expect(screen.getByTestId('gsheets-managed-placeholder')).toBeInTheDocument();
       expect(screen.queryByTestId('gsheets-oauth-connect-btn')).not.toBeInTheDocument();
     });
 
-    it('is unsatisfied until either a key is pasted or the box is ticked', async () => {
+    it("defaults to Dalgo's key on create, so auth is satisfied with nothing typed", () => {
       const onAuthSatisfiedChange = jest.fn();
       render(<Harness onAuthSatisfiedChange={onAuthSatisfiedChange} />);
 
+      expect(screen.getByTestId('gsheets-managed-steps')).toBeInTheDocument();
+      expect(onAuthSatisfiedChange).toHaveBeenLastCalledWith(true);
+    });
+
+    it('is unsatisfied once the box is unticked, until a key is pasted', async () => {
+      const onAuthSatisfiedChange = jest.fn();
+      render(<Harness onAuthSatisfiedChange={onAuthSatisfiedChange} />);
+
+      await userEvent.click(screen.getByTestId('gsheets-use-managed-checkbox'));
       expect(onAuthSatisfiedChange).toHaveBeenLastCalledWith(false);
 
       await userEvent.type(screen.getByRole('textbox', { name: /Service Account/i }), '{{"a":1}');
@@ -260,18 +270,21 @@ describe('GoogleSheetsForm', () => {
     it('keeps the checkbox visible on create even once a key is typed', async () => {
       render(<Harness />);
 
+      await userEvent.click(screen.getByTestId('gsheets-use-managed-checkbox'));
       await userEvent.type(screen.getByRole('textbox', { name: /Service Account/i }), '{{"a":1}');
 
       expect(screen.getByTestId('gsheets-use-managed-checkbox')).toBeInTheDocument();
     });
 
-    it('ticking shows the share steps and a stand-in, and satisfies auth', async () => {
+    it('re-ticking shows the share steps and a stand-in, and satisfies auth', async () => {
       const onAuthSatisfiedChange = jest.fn();
       let authType: unknown;
       render(
         <Harness onAuthSatisfiedChange={onAuthSatisfiedChange} onAuthType={(v) => (authType = v)} />
       );
 
+      // Off and back on, so this still exercises the tick itself rather than the create default.
+      await userEvent.click(screen.getByTestId('gsheets-use-managed-checkbox'));
       await userEvent.click(screen.getByTestId('gsheets-use-managed-checkbox'));
 
       expect(screen.getByTestId('gsheets-managed-steps')).toBeInTheDocument();
@@ -288,6 +301,7 @@ describe('GoogleSheetsForm', () => {
       render(<Harness onServiceValue={(v) => values.push(v)} />);
 
       await userEvent.click(screen.getByTestId('gsheets-use-managed-checkbox'));
+      await userEvent.click(screen.getByTestId('gsheets-use-managed-checkbox'));
 
       expect(values.every((v) => !String(v ?? '').includes('*'))).toBe(true);
       expect(values.at(-1) ?? '').toBe('');
@@ -296,6 +310,8 @@ describe('GoogleSheetsForm', () => {
     it('gives a typed key back when the box is unticked', async () => {
       render(<Harness />);
       const field = () => screen.getByRole('textbox', { name: /Service Account/i });
+      // Untick to get at the field, type their own key, tick, untick again.
+      await userEvent.click(screen.getByTestId('gsheets-use-managed-checkbox'));
       await userEvent.type(field(), '{{"a":1}');
 
       await userEvent.click(screen.getByTestId('gsheets-use-managed-checkbox'));

--- a/components/ingest/sources/custom/__tests__/google-sheets-form.test.tsx
+++ b/components/ingest/sources/custom/__tests__/google-sheets-form.test.tsx
@@ -4,6 +4,13 @@ import { useForm, useWatch, type FieldValues, type UseFormTrigger } from 'react-
 import { GoogleSheetsForm } from '../GoogleSheetsForm';
 import type { ParsedSpec, FieldNode } from '@/components/connectors/types';
 
+// MANAGED-SA bridge. Null = this deployment ships no managed key, which is the pre-bridge
+// behaviour every OAuth test below assumes; individual tests opt in by setting it.
+let mockManaged: { email: string | null } | null = null;
+jest.mock('@/hooks/api/useSources', () => ({
+  useManagedServiceAccount: () => ({ managed: mockManaged, isLoading: false }),
+}));
+
 const credentials: FieldNode = {
   type: 'oneOf',
   path: ['credentials'],
@@ -57,22 +64,36 @@ function Harness({
   connected = false,
   onAuthType,
   parsedSpec = spec,
+  onAuthSatisfiedChange,
+  savedKey,
+  mode = 'create',
+  onServiceValue,
 }: {
   connected?: boolean;
   onAuthType?: (v: unknown) => void;
   parsedSpec?: ParsedSpec;
+  onAuthSatisfiedChange?: (satisfied: boolean) => void;
+  /** Simulates edit mode: a source whose saved config already carries a service-account key. */
+  savedKey?: string;
+  mode?: 'create' | 'edit';
+  onServiceValue?: (v: unknown) => void;
 }) {
   const { control, setValue } = useForm<FieldValues>({
-    defaultValues: { credentials: { auth_type: 'Client' } },
+    defaultValues: savedKey
+      ? { credentials: { auth_type: 'Service', service_account_info: savedKey } }
+      : { credentials: { auth_type: 'Client' } },
   });
   const authType = useWatch({ control, name: 'credentials.auth_type' });
   onAuthType?.(authType);
+  const serviceInfo = useWatch({ control, name: 'credentials.service_account_info' });
+  onServiceValue?.(serviceInfo);
   return (
     <GoogleSheetsForm
       parsedSpec={parsedSpec}
       control={control}
       setValue={setValue}
-      mode="create"
+      mode={mode}
+      onAuthSatisfiedChange={onAuthSatisfiedChange}
       oauth={{
         connected,
         busy: false,
@@ -85,6 +106,10 @@ function Harness({
 }
 
 describe('GoogleSheetsForm', () => {
+  beforeEach(() => {
+    mockManaged = null;
+  });
+
   it('renders the spreadsheet link and a Google sign-in button, no auth dropdown', () => {
     render(<Harness />);
     expect(screen.getByText('Spreadsheet Link')).toBeInTheDocument();
@@ -200,5 +225,103 @@ describe('GoogleSheetsForm', () => {
 
     expect(isValid).toBe(true);
     expect(screen.queryByText('Service Account Information. is required')).not.toBeInTheDocument();
+  });
+
+  // MANAGED-SA bridge — remove this block along with the bridge once Google OAuth
+  // verification lands and the sign-in button comes back.
+  // MANAGED-SA bridge — remove with the bridge.
+  describe('with a Dalgo-managed service account', () => {
+    const MANAGED_EMAIL = 'dalgo-gsheets@dalgo-test.iam.gserviceaccount.com';
+    const OWN_KEY = '{"client_email":"theirs@x.iam.gserviceaccount.com"}';
+
+    beforeEach(() => {
+      mockManaged = { email: MANAGED_EMAIL };
+    });
+
+    it('replaces Google sign-in with the key field plus a checkbox under it', () => {
+      render(<Harness />);
+
+      expect(screen.getByTestId('gsheets-auth-choice')).toBeInTheDocument();
+      expect(screen.getByTestId('gsheets-key-field')).toBeInTheDocument();
+      expect(screen.getByTestId('gsheets-use-managed-checkbox')).toBeInTheDocument();
+      expect(screen.queryByTestId('gsheets-oauth-connect-btn')).not.toBeInTheDocument();
+    });
+
+    it('is unsatisfied until either a key is pasted or the box is ticked', async () => {
+      const onAuthSatisfiedChange = jest.fn();
+      render(<Harness onAuthSatisfiedChange={onAuthSatisfiedChange} />);
+
+      expect(onAuthSatisfiedChange).toHaveBeenLastCalledWith(false);
+
+      await userEvent.type(screen.getByRole('textbox', { name: /Service Account/i }), '{{"a":1}');
+      expect(onAuthSatisfiedChange).toHaveBeenLastCalledWith(true);
+    });
+
+    it('keeps the checkbox visible on create even once a key is typed', async () => {
+      render(<Harness />);
+
+      await userEvent.type(screen.getByRole('textbox', { name: /Service Account/i }), '{{"a":1}');
+
+      expect(screen.getByTestId('gsheets-use-managed-checkbox')).toBeInTheDocument();
+    });
+
+    it('ticking shows the share steps and a stand-in, and satisfies auth', async () => {
+      const onAuthSatisfiedChange = jest.fn();
+      let authType: unknown;
+      render(
+        <Harness onAuthSatisfiedChange={onAuthSatisfiedChange} onAuthType={(v) => (authType = v)} />
+      );
+
+      await userEvent.click(screen.getByTestId('gsheets-use-managed-checkbox'));
+
+      expect(screen.getByTestId('gsheets-managed-steps')).toBeInTheDocument();
+      expect(screen.getByTestId('gsheets-managed-email')).toHaveTextContent(MANAGED_EMAIL);
+      expect(screen.getByTestId('gsheets-managed-placeholder')).toBeInTheDocument();
+      expect(onAuthSatisfiedChange).toHaveBeenLastCalledWith(true);
+      expect(authType).toBe('Service');
+    });
+
+    // The asterisks are cosmetic: sending them would make the backend see a filled slot and skip
+    // the injection, handing Airbyte a key made of stars.
+    it('never puts the stand-in asterisks into the form value', async () => {
+      const values: unknown[] = [];
+      render(<Harness onServiceValue={(v) => values.push(v)} />);
+
+      await userEvent.click(screen.getByTestId('gsheets-use-managed-checkbox'));
+
+      expect(values.every((v) => !String(v ?? '').includes('*'))).toBe(true);
+      expect(values.at(-1) ?? '').toBe('');
+    });
+
+    it('gives a typed key back when the box is unticked', async () => {
+      render(<Harness />);
+      const field = () => screen.getByRole('textbox', { name: /Service Account/i });
+      await userEvent.type(field(), '{{"a":1}');
+
+      await userEvent.click(screen.getByTestId('gsheets-use-managed-checkbox'));
+      expect(screen.getByTestId('gsheets-managed-placeholder')).toBeInTheDocument();
+
+      await userEvent.click(screen.getByTestId('gsheets-use-managed-checkbox'));
+      expect(field()).toHaveValue('{"a":1}');
+    });
+
+    // Edit mode: which key a saved source uses is not recorded, so the checkbox must not appear
+    // (it would imply we know) and the key must survive untouched.
+    it('hides the checkbox and keeps the key when a source already has one', () => {
+      render(<Harness mode="edit" savedKey={OWN_KEY} />);
+
+      expect(screen.queryByTestId('gsheets-use-managed-checkbox')).not.toBeInTheDocument();
+      expect(screen.getByTestId('gsheets-saved-key-note')).toBeInTheDocument();
+      expect(screen.getByRole('textbox', { name: /Service Account/i })).toHaveValue(OWN_KEY);
+    });
+
+    it('brings the checkbox back once the saved key is cleared', async () => {
+      render(<Harness mode="edit" savedKey={OWN_KEY} />);
+
+      await userEvent.clear(screen.getByRole('textbox', { name: /Service Account/i }));
+
+      expect(screen.getByTestId('gsheets-use-managed-checkbox')).toBeInTheDocument();
+      expect(screen.queryByTestId('gsheets-saved-key-note')).not.toBeInTheDocument();
+    });
   });
 });

--- a/components/ingest/sources/custom/types.ts
+++ b/components/ingest/sources/custom/types.ts
@@ -28,6 +28,9 @@ export interface CustomSourceFormProps {
   mode: 'create' | 'edit';
   /** Supplied only for Google Sheets; other forms ignore it. */
   oauth?: CustomSourceOAuth;
+  /** Google Sheets only. The host can't infer this from the config: the managed option leaves
+   *  credentials empty on purpose, so empty means "backend fills it in", not "nothing chosen". */
+  onAuthSatisfiedChange?: (satisfied: boolean) => void;
 }
 
 // Per-source config for the friendly connection view. Drives stream relabeling

--- a/components/ingest/sources/wizard/CreateSourceStep.tsx
+++ b/components/ingest/sources/wizard/CreateSourceStep.tsx
@@ -178,10 +178,15 @@ export function CreateSourceStep({ def, onCreated, onBack }: Props) {
   const serviceValue = useWatch({ control, name: servicePath || '__none__' }) as string | undefined;
   const serviceProvided = !!serviceValue?.trim();
 
-  // Clear the auth error the moment either auth method is satisfied.
+  // MANAGED-SA: "use Dalgo's key" leaves credentials empty on purpose, so watching form fields
+  // can't tell it from "nothing chosen" — the form reports its own verdict.
+  const [formAuthSatisfied, setFormAuthSatisfied] = useState(false);
+  const authSatisfied = !!oauthRef || serviceProvided || formAuthSatisfied;
+
+  // Clear the auth error the moment any auth method is satisfied.
   useEffect(() => {
-    if (oauthRef || serviceProvided) setAuthError(null);
-  }, [oauthRef, serviceProvided]);
+    if (authSatisfied) setAuthError(null);
+  }, [authSatisfied]);
 
   // Validate required fields, then run the appropriate create flow. Spec-driven
   // fields self-report inline via react-hook-form's `trigger`; the source name and
@@ -192,8 +197,8 @@ export function CreateSourceStep({ def, onCreated, onBack }: Props) {
     const fieldsOk = await trigger();
 
     let authOk = true;
-    if (isGoogleSheets && !oauthRef && !serviceProvided) {
-      setAuthError('Sign in with Google or paste a service-account JSON to continue');
+    if (isGoogleSheets && !authSatisfied) {
+      setAuthError('Choose an authentication method to continue');
       authOk = false;
     }
 
@@ -208,8 +213,7 @@ export function CreateSourceStep({ def, onCreated, onBack }: Props) {
     validateName,
     trigger,
     isGoogleSheets,
-    oauthRef,
-    serviceProvided,
+    authSatisfied,
     useGoogleOAuthFlow,
     handleCreateGoogle,
     save,
@@ -270,6 +274,7 @@ export function CreateSourceStep({ def, onCreated, onBack }: Props) {
               disabled={busy}
               mode="create"
               nameField={custom ? nameField : undefined}
+              onAuthSatisfiedChange={isGoogleSheets ? setFormAuthSatisfied : undefined}
               oauth={
                 isGoogleSheets
                   ? ({

--- a/components/ingest/sources/wizard/CreateSourceStep.tsx
+++ b/components/ingest/sources/wizard/CreateSourceStep.tsx
@@ -198,7 +198,7 @@ export function CreateSourceStep({ def, onCreated, onBack }: Props) {
 
     let authOk = true;
     if (isGoogleSheets && !authSatisfied) {
-      setAuthError('Choose an authentication method to continue');
+      setAuthError('Paste a service-account key, or tick “Use Dalgo’s service account”');
       authOk = false;
     }
 

--- a/components/ingest/sources/wizard/__tests__/create-source-step.test.tsx
+++ b/components/ingest/sources/wizard/__tests__/create-source-step.test.tsx
@@ -68,6 +68,9 @@ jest.mock('@/hooks/api/useSources', () => ({
   useSourceSpec: () => ({ data: mockSourceSpec, isLoading: false }),
   getSourceOAuthConsent: jest.fn(),
   createOAuthSource: jest.fn(),
+  // MANAGED-SA bridge off: no deployment-managed key, so the form keeps the OAuth UI these
+  // tests assert on. Coverage of the managed path lives in google-sheets-form.test.tsx.
+  useManagedServiceAccount: () => ({ managed: null, isLoading: false }),
 }));
 const mockSave = jest.fn();
 jest.mock('@/hooks/useSourceSave', () => ({

--- a/hooks/__tests__/useSourceSave.test.ts
+++ b/hooks/__tests__/useSourceSave.test.ts
@@ -69,7 +69,7 @@ it('save() success: WS check succeeds → createSource is called and onSaved fir
     sourceDefId: 'pg-def',
     // The connector's definition name rides along so the backend can tell whether to fill in
     // Dalgo's managed Google service-account key. Sent on every source, not just Sheets.
-    sourceName: 'Postgres',
+    sourceDefName: 'Postgres',
     config: { host: 'db.example', port: 5432 },
   });
   expect(result.current.loading).toBe(true);
@@ -86,7 +86,7 @@ it('save() success: WS check succeeds → createSource is called and onSaved fir
     expect(createSource).toHaveBeenCalledWith({
       name: 'My Source',
       sourceDefId: 'pg-def',
-      sourceName: 'Postgres',
+      sourceDefName: 'Postgres',
       config: { host: 'db.example', port: 5432 },
     })
   );

--- a/hooks/__tests__/useSourceSave.test.ts
+++ b/hooks/__tests__/useSourceSave.test.ts
@@ -67,6 +67,9 @@ it('save() success: WS check succeeds → createSource is called and onSaved fir
   expect(mockWs.sendOrQueue).toHaveBeenCalledWith({
     name: 'My Source',
     sourceDefId: 'pg-def',
+    // The connector's definition name rides along so the backend can tell whether to fill in
+    // Dalgo's managed Google service-account key. Sent on every source, not just Sheets.
+    sourceName: 'Postgres',
     config: { host: 'db.example', port: 5432 },
   });
   expect(result.current.loading).toBe(true);
@@ -83,6 +86,7 @@ it('save() success: WS check succeeds → createSource is called and onSaved fir
     expect(createSource).toHaveBeenCalledWith({
       name: 'My Source',
       sourceDefId: 'pg-def',
+      sourceName: 'Postgres',
       config: { host: 'db.example', port: 5432 },
     })
   );

--- a/hooks/api/useSources.ts
+++ b/hooks/api/useSources.ts
@@ -9,6 +9,7 @@ import type {
   CreateOAuthSourcePayload,
   UpdateOAuthSourcePayload,
   CreateOAuthSourceResponse,
+  ManagedServiceAccount,
 } from '@/types/source';
 import type { ConnectionSpecification } from '@/components/connectors/types';
 
@@ -64,6 +65,17 @@ export function useSource(sourceId: string | null) {
     { revalidateOnFocus: false }
   );
   return { data, isLoading, isError: error, mutate };
+}
+
+/** MANAGED-SA bridge — the address users share their spreadsheet with, or null when the
+ * deployment ships no key. Fixed per deployment, so fetched once and never revalidated. */
+export function useManagedServiceAccount(enabled: boolean) {
+  const { data, isLoading } = useSWR<ManagedServiceAccount>(
+    enabled ? '/api/airbyte/sources/google_sheets/managed_service_account/' : null,
+    apiGet,
+    { revalidateOnFocus: false, revalidateIfStale: false, shouldRetryOnError: false }
+  );
+  return { managed: data ?? null, isLoading };
 }
 
 // ============ Mutation Functions ============

--- a/hooks/useSourceSave.ts
+++ b/hooks/useSourceSave.ts
@@ -65,9 +65,9 @@ export function useSourceSave({
       setSetupLogs([]);
       setPendingName(name);
       setLoading(true);
-      sendOrQueue({ name, sourceDefId, config: getConfig() });
+      sendOrQueue({ name, sourceDefId, sourceName: sourceDefName, config: getConfig() });
     },
-    [sourceDefId, getConfig, sendOrQueue]
+    [sourceDefId, sourceDefName, getConfig, sendOrQueue]
   );
 
   useEffect(() => {
@@ -84,6 +84,7 @@ export function useSourceSave({
           const created = await createSource({
             name: pendingName!,
             sourceDefId: sourceDefId!,
+            sourceName: sourceDefName,
             config: getConfig(),
           });
           toastSuccess.created('Source');

--- a/hooks/useSourceSave.ts
+++ b/hooks/useSourceSave.ts
@@ -65,7 +65,7 @@ export function useSourceSave({
       setSetupLogs([]);
       setPendingName(name);
       setLoading(true);
-      sendOrQueue({ name, sourceDefId, sourceName: sourceDefName, config: getConfig() });
+      sendOrQueue({ name, sourceDefId, sourceDefName, config: getConfig() });
     },
     [sourceDefId, sourceDefName, getConfig, sendOrQueue]
   );
@@ -84,7 +84,7 @@ export function useSourceSave({
           const created = await createSource({
             name: pendingName!,
             sourceDefId: sourceDefId!,
-            sourceName: sourceDefName,
+            sourceDefName,
             config: getConfig(),
           });
           toastSuccess.created('Source');

--- a/types/source.ts
+++ b/types/source.ts
@@ -20,6 +20,9 @@ export interface CreateSourcePayload {
   name: string;
   sourceDefId: string;
   config: Record<string, unknown>;
+  /** Source-DEFINITION name (e.g. "Google Sheets"). Tells the backend whether to fill in
+   *  Dalgo's managed service-account key. */
+  sourceName: string;
 }
 
 export interface UpdateSourcePayload {
@@ -27,6 +30,9 @@ export interface UpdateSourcePayload {
   sourceDefId: string;
   config: Record<string, unknown>;
   sourceId: string;
+  /** Source-DEFINITION name (e.g. "Google Sheets"). Tells the backend whether to fill in
+   *  Dalgo's managed service-account key. */
+  sourceName: string;
 }
 
 /** Response from starting the Google OAuth flow (Variant A): the Google consent URL
@@ -57,4 +63,10 @@ export type UpdateOAuthSourcePayload = CreateOAuthSourcePayload;
 /** Response from creating the OAuth source: the saved source's id */
 export interface CreateOAuthSourceResponse {
   sourceId: string;
+}
+
+/** MANAGED-SA bridge — the Dalgo service account users share their spreadsheet with. */
+export interface ManagedServiceAccount {
+  /** null when no usable key is configured — that IS the "bridge is off" signal. */
+  email: string | null;
 }

--- a/types/source.ts
+++ b/types/source.ts
@@ -22,7 +22,7 @@ export interface CreateSourcePayload {
   config: Record<string, unknown>;
   /** Source-DEFINITION name (e.g. "Google Sheets"). Tells the backend whether to fill in
    *  Dalgo's managed service-account key. */
-  sourceName: string;
+  sourceDefName: string;
 }
 
 export interface UpdateSourcePayload {
@@ -32,7 +32,7 @@ export interface UpdateSourcePayload {
   sourceId: string;
   /** Source-DEFINITION name (e.g. "Google Sheets"). Tells the backend whether to fill in
    *  Dalgo's managed service-account key. */
-  sourceName: string;
+  sourceDefName: string;
 }
 
 /** Response from starting the Google OAuth flow (Variant A): the Google consent URL


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added managed service-account authentication for Google Sheets.
  * Users can choose between a managed account and their own service-account key.
  * Added sharing instructions and click-to-copy account details.
  * Preserved entered credentials when switching authentication options.
* **Improvements**
  * Authentication validation now recognizes all supported methods and prevents incomplete saves.
  * Source connection and save requests now include the selected source name.
* **Tests**
  * Expanded coverage for authentication choices, credential handling, and edit-mode behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->