### PR TITLE
Redesign Ingest per-table settings

### DIFF
--- a/components/connections/__tests__/connection-form-body.test.tsx
+++ b/components/connections/__tests__/connection-form-body.test.tsx
@@ -6,10 +6,11 @@
  */
 
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ConnectionFormBody } from '../connection-form-body';
 import { FormMode } from '@/constants/connections';
+import { createConnection, triggerSync } from '@/hooks/api/useConnections';
 import type { Connection } from '@/types/connections';
 
 // ============ Mocks ============
@@ -34,13 +35,19 @@ jest.mock('@/hooks/api/useConnections', () => ({
   triggerSync: jest.fn(),
 }));
 
-// Mutable so a test can simulate discovered streams (the help panel + streams
-// table only appear once discovery returns rows). Prefixed `mock` for hoisting.
+// Mutable so a test can simulate discovered streams (the settings split only
+// appears once discovery returns rows). Prefixed `mock` for hoisting.
 let mockStreams: unknown[] = [];
+let mockHasSelectedStreams = false;
+let mockStreamTableProps: Record<string, unknown> | null = null;
+let mockSettingsPanelProps: Record<string, unknown> | null = null;
 
 afterEach(() => {
   mockConnectionData = null;
   mockStreams = [];
+  mockHasSelectedStreams = false;
+  mockStreamTableProps = null;
+  mockSettingsPanelProps = null;
 });
 
 jest.mock('@/hooks/useBackendWebSocket', () => ({
@@ -55,19 +62,38 @@ jest.mock('@/hooks/useBackendWebSocket', () => ({
 }));
 
 jest.mock('../stream-config-table', () => ({
-  StreamConfigTable: (_props: Record<string, unknown>) => <div data-testid="stream-config-table" />,
+  StreamConfigTable: (props: Record<string, unknown>) => {
+    mockStreamTableProps = props;
+    return (
+      <button
+        type="button"
+        data-testid="stream-config-table"
+        onClick={() => (props.onOpenSettings as (streamName: string) => void)('sheet1')}
+      >
+        Open settings
+      </button>
+    );
+  },
 }));
 
-jest.mock('../connection-help-panel', () => ({
-  ConnectionHelpPanel: (_props: Record<string, unknown>) => (
-    <div data-testid="connection-help-panel" />
-  ),
+jest.mock('../stream-settings-panel', () => ({
+  StreamSettingsPanel: (props: Record<string, unknown>) => {
+    mockSettingsPanelProps = props;
+    return (
+      <button
+        type="button"
+        data-testid="stream-settings-panel"
+        onClick={() => (props.onClose as () => void)()}
+      >
+        Close settings
+      </button>
+    );
+  },
 }));
 
 jest.mock('../hooks/useStreamConfig', () => ({
   useStreamConfig: (): Record<string, unknown> => ({
     streams: mockStreams,
-    setStreams: jest.fn(),
     initializeStreams: jest.fn(),
     streamSearch: '',
     setStreamSearch: jest.fn(),
@@ -80,11 +106,12 @@ jest.mock('../hooks/useStreamConfig', () => ({
     updateStreamCursorField: jest.fn(),
     updateStreamPrimaryKey: jest.fn(),
     toggleColumn: jest.fn(),
+    updateCastType: jest.fn(),
     toggleStreamExpand: jest.fn(),
     handleIncrementalAllToggle: jest.fn(),
     filteredStreams: mockStreams,
     allSelected: false,
-    hasSelectedStreams: false,
+    hasSelectedStreams: mockHasSelectedStreams,
   }),
 }));
 
@@ -158,8 +185,8 @@ describe('ConnectionFormBody', () => {
   });
 });
 
-describe('ConnectionFormBody split help + custom view', () => {
-  it('hides the help panel until streams are discovered, then shows it', () => {
+describe('ConnectionFormBody settings inspector + custom view', () => {
+  it('shows the settings placeholder after streams are discovered', () => {
     const { rerender } = render(
       <ConnectionFormBody
         mode={FormMode.CREATE}
@@ -168,11 +195,9 @@ describe('ConnectionFormBody split help + custom view', () => {
         onCancel={jest.fn()}
       />
     );
-    // No streams yet → no empty docs column.
-    expect(screen.queryByTestId('connection-help-panel')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('stream-settings-placeholder')).not.toBeInTheDocument();
 
-    // Discovery returns rows → panel appears.
-    mockStreams = [{ name: 'sheet1', selected: true }];
+    mockStreams = [{ name: 'sheet1', selected: true, columns: [] }];
     rerender(
       <ConnectionFormBody
         mode={FormMode.CREATE}
@@ -181,10 +206,10 @@ describe('ConnectionFormBody split help + custom view', () => {
         onCancel={jest.fn()}
       />
     );
-    expect(screen.getByTestId('connection-help-panel')).toBeInTheDocument();
+    expect(screen.getByTestId('stream-settings-placeholder')).toBeInTheDocument();
   });
 
-  it('tucks schema + normalize under Advanced options for a generic source too', () => {
+  it('keeps Normalize visible and tucks Destination Schema under Advanced options', () => {
     render(
       <ConnectionFormBody
         mode={FormMode.CREATE}
@@ -195,10 +220,11 @@ describe('ConnectionFormBody split help + custom view', () => {
     );
     // Every connection now uses the bottom Advanced-options section, collapsed.
     expect(screen.getByTestId('advanced-options-toggle')).toBeInTheDocument();
+    expect(screen.getByTestId('normalize-toggle')).toBeInTheDocument();
     expect(screen.queryByTestId('destination-schema-input')).not.toBeInTheDocument();
   });
 
-  it('tucks schema + normalize under Advanced options for a custom source', () => {
+  it('uses the same connection-level disclosure for a custom source', () => {
     render(
       <ConnectionFormBody
         mode={FormMode.CREATE}
@@ -223,18 +249,129 @@ describe('ConnectionFormBody split help + custom view', () => {
       />
     );
 
-    await user.click(screen.getByTestId('advanced-options-toggle'));
-    await user.hover(
-      screen.getByRole('button', {
-        name: 'About Normalize data after sync',
-      })
-    );
+    const helpTrigger = screen.getByRole('button', {
+      name: 'About Normalize data after sync',
+    });
+    await user.hover(helpTrigger);
 
     const tooltip = await screen.findByRole('tooltip');
     expect(tooltip).toHaveTextContent(
       'Organizes the raw records copied from your source into structured warehouse tables'
     );
     expect(tooltip).toHaveTextContent('adds an extra processing step after each sync');
+  });
+
+  it('opens and closes one table settings panel from the streams table', async () => {
+    const user = userEvent.setup();
+    mockStreams = [{ name: 'sheet1', selected: true, columns: [] }];
+    render(
+      <ConnectionFormBody
+        mode={FormMode.CREATE}
+        presetSourceId="src-1"
+        onSuccess={jest.fn()}
+        onCancel={jest.fn()}
+      />
+    );
+
+    expect(screen.getByTestId('stream-settings-placeholder')).toBeInTheDocument();
+    await user.click(screen.getByTestId('stream-config-table'));
+
+    expect(screen.getByTestId('stream-settings-panel')).toBeInTheDocument();
+    expect(mockSettingsPanelProps?.stream).toEqual(mockStreams[0]);
+
+    await user.click(screen.getByTestId('stream-settings-panel'));
+    expect(screen.getByTestId('stream-settings-placeholder')).toBeInTheDocument();
+  });
+
+  it('enables Cast to for Google Sheets only', async () => {
+    const user = userEvent.setup();
+    mockStreams = [{ name: 'sheet1', selected: true, columns: [] }];
+    const { rerender } = render(
+      <ConnectionFormBody
+        mode={FormMode.CREATE}
+        presetSourceId="gs-1"
+        onSuccess={jest.fn()}
+        onCancel={jest.fn()}
+      />
+    );
+
+    await user.click(screen.getByTestId('stream-config-table'));
+    expect(mockSettingsPanelProps?.showCastColumn).toBe(true);
+    expect(mockSettingsPanelProps?.showIncremental).toBe(false);
+
+    mockSettingsPanelProps = null;
+    rerender(
+      <ConnectionFormBody
+        mode={FormMode.CREATE}
+        presetSourceId="kb-1"
+        onSuccess={jest.fn()}
+        onCancel={jest.fn()}
+      />
+    );
+
+    expect(mockStreamTableProps).not.toBeNull();
+    await user.click(screen.getByTestId('stream-config-table'));
+    expect(mockSettingsPanelProps?.showCastColumn).toBe(false);
+  });
+
+  it('preserves Google Sheets column casts in the connection save payload', async () => {
+    const user = userEvent.setup();
+    mockHasSelectedStreams = true;
+    mockStreams = [
+      {
+        name: 'sheet1',
+        selected: true,
+        supportsIncremental: false,
+        syncMode: 'full_refresh',
+        destinationSyncMode: 'overwrite',
+        cursorField: '',
+        primaryKey: [],
+        columns: [
+          {
+            name: 'respondent_age',
+            data_type: 'String',
+            selected: true,
+            cast_to_type: 'integer',
+          },
+          {
+            name: 'respondent_name',
+            data_type: 'String',
+            selected: true,
+            cast_to_type: null,
+          },
+        ],
+      },
+    ];
+    jest.mocked(createConnection).mockResolvedValue({
+      connectionId: 'connection-1',
+      deploymentId: 'deployment-1',
+    } as never);
+    jest.mocked(triggerSync).mockResolvedValue(undefined as never);
+
+    render(
+      <ConnectionFormBody
+        mode={FormMode.CREATE}
+        presetSourceId="gs-1"
+        onSuccess={jest.fn()}
+        onCancel={jest.fn()}
+      />
+    );
+
+    await user.click(screen.getByTestId('save-connection-btn'));
+
+    await waitFor(() => expect(createConnection).toHaveBeenCalledTimes(1));
+    expect(jest.mocked(createConnection).mock.calls[0][0]).toMatchObject({
+      post_sync_transform: {
+        ops: [
+          {
+            type: 'cast',
+            schema: 'staging',
+            table: 'sheet1',
+            config: { respondent_age: 'integer' },
+          },
+        ],
+      },
+    });
   });
 
   it('reports header info (not a body chip) for a custom source in create', () => {

--- a/components/connections/__tests__/connection-form.test.tsx
+++ b/components/connections/__tests__/connection-form.test.tsx
@@ -47,6 +47,7 @@ jest.mock('../hooks/useStreamConfig', () => ({
     updateStreamCursorField: jest.fn(),
     updateStreamPrimaryKey: jest.fn(),
     toggleColumn: jest.fn(),
+    updateCastType: jest.fn(),
     toggleStreamExpand: jest.fn(),
     handleIncrementalAllToggle: jest.fn(),
     filteredStreams: [],

--- a/components/connections/__tests__/stream-config-table.test.tsx
+++ b/components/connections/__tests__/stream-config-table.test.tsx
@@ -1,13 +1,13 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { StreamConfigTable } from '../stream-config-table';
-import { SyncMode, DestinationSyncMode } from '@/constants/connections';
+import { DestinationSyncMode, SyncMode } from '@/constants/connections';
 import type { SourceStream } from '@/types/connections';
 
-const stream = (name: string, supportsIncremental: boolean): SourceStream => ({
+const makeStream = (name: string, selected = true): SourceStream => ({
   name,
-  selected: true,
-  supportsIncremental,
+  selected,
+  supportsIncremental: true,
   syncMode: SyncMode.FULL_REFRESH,
   destinationSyncMode: DestinationSyncMode.OVERWRITE,
   cursorField: '',
@@ -17,208 +17,103 @@ const stream = (name: string, supportsIncremental: boolean): SourceStream => ({
   primaryKeyConfig: { sourceDefinedPrimaryKey: false, selected: [], all: [] },
 });
 
+const streams = [makeStream('form_one'), makeStream('form_two', false)];
+
 const baseProps = {
-  streams: [stream('form_one', true)],
-  filteredStreams: [stream('form_one', true)],
-  allSelected: true,
-  incrementalAllStreams: false,
-  expandedStreams: new Set<string>(),
+  streams,
+  filteredStreams: streams,
+  allSelected: false,
   streamSearch: '',
   disabled: false,
   isSaving: false,
+  activeStreamName: null as string | null,
   onStreamSearchChange: jest.fn(),
   onToggleAllStreams: jest.fn(),
-  onIncrementalAllToggle: jest.fn(),
   onToggleStream: jest.fn(),
-  onUpdateStreamSyncMode: jest.fn(),
-  onUpdateStreamDestMode: jest.fn(),
-  onUpdateStreamCursorField: jest.fn(),
-  onUpdateStreamPrimaryKey: jest.fn(),
-  onToggleStreamExpand: jest.fn(),
-  onToggleColumn: jest.fn(),
-  onUpdateCastType: jest.fn(),
+  onOpenSettings: jest.fn(),
 };
 
-describe('StreamConfigTable progressive disclosure', () => {
-  it('hides advanced columns when advancedOpen is false', () => {
-    render(<StreamConfigTable {...baseProps} advancedOpen={false} onToggleAdvanced={jest.fn()} />);
-    expect(screen.getByTestId('stream-toggle-form_one')).toBeInTheDocument();
-    expect(screen.queryByTestId('stream-incremental-form_one')).not.toBeInTheDocument();
-    expect(screen.queryByText('Columns')).not.toBeInTheDocument();
-    expect(screen.queryByTestId('expand-columns-form_one')).not.toBeInTheDocument();
-    expect(screen.getByTestId('advanced-streams-toggle')).toBeInTheDocument();
+describe('StreamConfigTable', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
   });
 
-  it('keeps Google Sheets columns accessible while advanced settings are closed', async () => {
-    const user = userEvent.setup();
-    const onConceptFocus = jest.fn();
-    render(
-      <StreamConfigTable
-        {...baseProps}
-        advancedOpen={false}
-        showCastColumn
-        showIncremental={false}
-        onConceptFocus={onConceptFocus}
-        onToggleAdvanced={jest.fn()}
-      />
-    );
+  it('keeps sync in the table and moves per-table options behind one settings action', () => {
+    render(<StreamConfigTable {...baseProps} />);
 
-    expect(screen.getByText('Columns')).toBeInTheDocument();
-    expect(screen.getByTestId('expand-columns-form_one')).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: 'Tables' })).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: 'Sync' })).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: 'Advanced settings' })).toBeInTheDocument();
+    expect(screen.getByRole('switch', { name: 'Sync form_one' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Open advanced settings for form_one' })
+    ).toBeInTheDocument();
+    expect(screen.queryByText('Incremental')).not.toBeInTheDocument();
     expect(screen.queryByText('Destination')).not.toBeInTheDocument();
-    expect(screen.queryByText('Incremental?')).not.toBeInTheDocument();
-    expect(screen.queryByText('Cursor Field')).not.toBeInTheDocument();
-    expect(screen.queryByText('Primary Key')).not.toBeInTheDocument();
-
-    await user.click(screen.getByTestId('concept-header-columns'));
-    expect(onConceptFocus).toHaveBeenCalledWith('columns');
   });
 
-  it('shows Google Sheets column names, detected types, and casts while advanced is closed', () => {
-    render(
-      <StreamConfigTable
-        {...baseProps}
-        advancedOpen={false}
-        showCastColumn
-        showIncremental={false}
-        expandedStreams={new Set(['form_one'])}
-        onToggleAdvanced={jest.fn()}
-      />
-    );
-
-    expect(screen.getByRole('columnheader', { name: 'Column' })).toBeInTheDocument();
-    expect(screen.getByRole('columnheader', { name: 'Type' })).toBeInTheDocument();
-    expect(screen.getByRole('columnheader', { name: 'Cast to' })).toBeInTheDocument();
-    expect(screen.getByText('col_a')).toBeInTheDocument();
-    expect(screen.getByText('string')).toBeInTheDocument();
-    expect(screen.getByTestId('cast-type-form_one-col_a')).toBeInTheDocument();
-  });
-
-  it('shows advanced columns when advancedOpen is true', () => {
-    render(<StreamConfigTable {...baseProps} advancedOpen onToggleAdvanced={jest.fn()} />);
-    expect(screen.getByTestId('stream-incremental-form_one')).toBeInTheDocument();
-  });
-
-  it('keeps the full advanced table readable inside a horizontal scroll region', () => {
-    render(<StreamConfigTable {...baseProps} advancedOpen onToggleAdvanced={jest.fn()} />);
-
-    expect(screen.getByRole('region', { name: 'Advanced per-table settings' })).toHaveClass(
-      'overflow-x-auto'
-    );
-    expect(screen.getByTestId('streams-table')).toHaveClass('min-w-[1080px]');
-  });
-
-  it('uses a smaller horizontal scroll width for Google Sheets advanced settings', () => {
-    render(
-      <StreamConfigTable
-        {...baseProps}
-        advancedOpen
-        showCastColumn
-        showIncremental={false}
-        onToggleAdvanced={jest.fn()}
-      />
-    );
-
-    expect(screen.getByRole('region', { name: 'Advanced per-table settings' })).toHaveClass(
-      'overflow-x-auto'
-    );
-    expect(screen.getByTestId('streams-table')).toHaveClass('min-w-[760px]');
-    expect(screen.getByTestId('streams-table')).not.toHaveClass('min-w-[1080px]');
-  });
-
-  it('does not force a wide table when no crowded advanced columns are present', () => {
-    render(
-      <StreamConfigTable
-        {...baseProps}
-        advancedOpen
-        showIncremental={false}
-        onToggleAdvanced={jest.fn()}
-      />
-    );
-
-    expect(screen.getByTestId('streams-table')).not.toHaveClass('min-w-[760px]');
-    expect(screen.getByTestId('streams-table')).not.toHaveClass('min-w-[1080px]');
-  });
-
-  it('uses the streamNoun for the column header', () => {
-    render(
-      <StreamConfigTable
-        {...baseProps}
-        advancedOpen
-        streamNoun="Tabs"
-        onToggleAdvanced={jest.fn()}
-      />
-    );
-    expect(screen.getByText('Tabs')).toBeInTheDocument();
-  });
-
-  it('hides the Incremental column when showIncremental is false', () => {
-    render(
-      <StreamConfigTable
-        {...baseProps}
-        advancedOpen
-        showIncremental={false}
-        onToggleAdvanced={jest.fn()}
-      />
-    );
-    expect(screen.queryByTestId('stream-incremental-form_one')).not.toBeInTheDocument();
-  });
-
-  it('hides Cursor Field and Primary Key when showIncremental is false, keeping Destination', () => {
-    render(
-      <StreamConfigTable
-        {...baseProps}
-        advancedOpen
-        showIncremental={false}
-        streamNoun="Sheets"
-        onToggleAdvanced={jest.fn()}
-      />
-    );
-    expect(screen.queryByText('Cursor Field')).not.toBeInTheDocument();
-    expect(screen.queryByText('Primary Key')).not.toBeInTheDocument();
-    expect(screen.getByText('Destination')).toBeInTheDocument();
-  });
-
-  it('omits dest modes not in allowedDestModes', () => {
-    render(
-      <StreamConfigTable
-        {...baseProps}
-        advancedOpen
-        allowedDestModes={[DestinationSyncMode.OVERWRITE, DestinationSyncMode.APPEND]}
-        onToggleAdvanced={jest.fn()}
-      />
-    );
-    // The Append/Dedup item must not be in the rendered select content.
-    expect(screen.queryByText('Append / Dedup')).not.toBeInTheDocument();
-  });
-
-  it('moves the help panel to a concept when its column header is clicked', async () => {
+  it('toggles sync for an individual table', async () => {
     const user = userEvent.setup();
-    const onConceptFocus = jest.fn();
-    render(
-      <StreamConfigTable
-        {...baseProps}
-        advancedOpen
-        onConceptFocus={onConceptFocus}
-        onToggleAdvanced={jest.fn()}
-      />
-    );
-    await user.click(screen.getByTestId('concept-header-cursor'));
-    expect(onConceptFocus).toHaveBeenCalledWith('cursor');
+    const onToggleStream = jest.fn();
+    render(<StreamConfigTable {...baseProps} onToggleStream={onToggleStream} />);
 
-    await user.click(screen.getByTestId('concept-header-sync'));
-    expect(onConceptFocus).toHaveBeenCalledWith('sync');
+    await user.click(screen.getByTestId('stream-toggle-form_one'));
+
+    expect(onToggleStream).toHaveBeenCalledWith('form_one');
   });
 
-  it('renders the "Select your" heading using the given streamNoun', () => {
+  it('opens the selected table settings and highlights its row', async () => {
+    const user = userEvent.setup();
+    const onOpenSettings = jest.fn();
+    const { rerender } = render(
+      <StreamConfigTable {...baseProps} onOpenSettings={onOpenSettings} />
+    );
+
+    await user.click(screen.getByTestId('open-stream-settings-form_two'));
+    expect(onOpenSettings).toHaveBeenCalledWith('form_two');
+
+    rerender(
+      <StreamConfigTable
+        {...baseProps}
+        activeStreamName="form_two"
+        onOpenSettings={onOpenSettings}
+      />
+    );
+    expect(screen.getByTestId('stream-row-form_two')).toHaveAttribute('data-active', 'true');
+    expect(screen.getByTestId('open-stream-settings-form_two')).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    );
+  });
+
+  it('shows high-volume table tools and toggles all streams', async () => {
+    const user = userEvent.setup();
+    const manyStreams = Array.from({ length: 6 }, (_, index) => makeStream(`form_${index}`));
+    const onToggleAllStreams = jest.fn();
     render(
       <StreamConfigTable
         {...baseProps}
-        streamNoun="Sheets"
-        advancedOpen={false}
-        onToggleAdvanced={jest.fn()}
+        streams={manyStreams}
+        filteredStreams={manyStreams}
+        allSelected
+        onToggleAllStreams={onToggleAllStreams}
       />
     );
-    expect(screen.getByText(/Select your sheets/)).toBeInTheDocument();
+
+    expect(screen.getByTestId('stream-filter-input')).toBeInTheDocument();
+    await user.click(screen.getByTestId('toggle-all-streams'));
+    expect(onToggleAllStreams).toHaveBeenCalledWith(false);
+  });
+
+  it('supports source-specific table nouns', () => {
+    render(<StreamConfigTable {...baseProps} streamNoun="Sheets" />);
+    expect(screen.getByRole('columnheader', { name: 'Sheets' })).toBeInTheDocument();
+    expect(screen.getByText('Select your sheets (1/2 selected)')).toBeInTheDocument();
+  });
+
+  it('keeps settings exploration available in read-only mode while disabling sync', () => {
+    render(<StreamConfigTable {...baseProps} disabled />);
+    expect(screen.getByTestId('stream-toggle-form_one')).toBeDisabled();
+    expect(screen.getByTestId('open-stream-settings-form_one')).not.toBeDisabled();
   });
 });

--- a/components/connections/__tests__/stream-settings-panel.test.tsx
+++ b/components/connections/__tests__/stream-settings-panel.test.tsx
@@ -1,0 +1,152 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { StreamSettingsPanel } from '../stream-settings-panel';
+import { DestinationSyncMode, SyncMode } from '@/constants/connections';
+import type { SourceStream } from '@/types/connections';
+
+const stream: SourceStream = {
+  name: 'survey_responses',
+  selected: true,
+  supportsIncremental: true,
+  syncMode: SyncMode.INCREMENTAL,
+  destinationSyncMode: DestinationSyncMode.APPEND_DEDUP,
+  cursorField: 'submission_time',
+  primaryKey: ['submission_id'],
+  columns: [
+    {
+      name: 'submission_time',
+      data_type: 'timestamp',
+      selected: true,
+      cast_to_type: null,
+    },
+    { name: 'submission_id', data_type: 'string', selected: true, cast_to_type: null },
+    { name: 'respondent_age', data_type: 'string', selected: true, cast_to_type: null },
+  ],
+  cursorFieldConfig: {
+    sourceDefinedCursor: false,
+    selected: ['submission_time'],
+    all: ['submission_time'],
+  },
+  primaryKeyConfig: {
+    sourceDefinedPrimaryKey: false,
+    selected: [['submission_id']],
+    all: [['submission_id']],
+  },
+};
+
+const baseProps = {
+  stream,
+  disabled: false,
+  isSaving: false,
+  columnsOpen: false,
+  onClose: jest.fn(),
+  onUpdateStreamSyncMode: jest.fn(),
+  onUpdateStreamDestMode: jest.fn(),
+  onUpdateStreamCursorField: jest.fn(),
+  onUpdateStreamPrimaryKey: jest.fn(),
+  onToggleColumns: jest.fn(),
+  onToggleColumn: jest.fn(),
+  onUpdateCastType: jest.fn(),
+};
+
+describe('StreamSettingsPanel', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('shows per-table controls with inline explanations and no duplicate sync control', () => {
+    render(<StreamSettingsPanel {...baseProps} />);
+
+    expect(screen.getByRole('heading', { name: 'Advanced settings' })).toBeInTheDocument();
+    expect(screen.getByTestId('settings-stream-name')).toHaveTextContent('survey_responses');
+    expect(screen.getByText('Incremental')).toBeInTheDocument();
+    expect(screen.getByText('Destination')).toBeInTheDocument();
+    expect(screen.getByText('Cursor field')).toBeInTheDocument();
+    expect(screen.getByText('Primary key')).toBeInTheDocument();
+    expect(
+      screen.getByText('Only bring in records added or changed since the last sync.')
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('switch', { name: 'Sync survey_responses' })).not.toBeInTheDocument();
+  });
+
+  it('expands Columns downward to show inclusion, name, and detected type', async () => {
+    const user = userEvent.setup();
+    const onToggleColumns = jest.fn();
+    const { rerender } = render(
+      <StreamSettingsPanel {...baseProps} onToggleColumns={onToggleColumns} />
+    );
+
+    const columnsButton = screen.getByTestId('toggle-stream-columns-survey_responses');
+    expect(columnsButton).toHaveAttribute('aria-expanded', 'false');
+    await user.click(columnsButton);
+    expect(onToggleColumns).toHaveBeenCalledWith('survey_responses');
+
+    rerender(<StreamSettingsPanel {...baseProps} columnsOpen onToggleColumns={onToggleColumns} />);
+    expect(screen.getByRole('columnheader', { name: 'Include' })).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: 'Column' })).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: 'Type' })).toBeInTheDocument();
+    expect(screen.getByText('respondent_age')).toBeInTheDocument();
+    expect(screen.getAllByText('string')).toHaveLength(2);
+  });
+
+  it('shows Cast to only when the source supports ingest casting', () => {
+    const { rerender } = render(<StreamSettingsPanel {...baseProps} columnsOpen />);
+    expect(screen.queryByRole('columnheader', { name: 'Cast to' })).not.toBeInTheDocument();
+
+    rerender(
+      <StreamSettingsPanel
+        {...baseProps}
+        stream={{
+          ...stream,
+          supportsIncremental: false,
+          syncMode: SyncMode.FULL_REFRESH,
+          destinationSyncMode: DestinationSyncMode.OVERWRITE,
+          cursorField: '',
+          primaryKey: [],
+        }}
+        columnsOpen
+        showIncremental={false}
+        showCastColumn
+        allowedDestModes={[DestinationSyncMode.OVERWRITE, DestinationSyncMode.APPEND]}
+      />
+    );
+
+    expect(screen.getByRole('columnheader', { name: 'Cast to' })).toBeInTheDocument();
+    expect(screen.getByTestId('cast-column-survey_responses-respondent_age')).toBeInTheDocument();
+    expect(screen.queryByText('Incremental')).not.toBeInTheDocument();
+    expect(screen.queryByText('Cursor field')).not.toBeInTheDocument();
+    expect(screen.queryByText('Primary key')).not.toBeInTheDocument();
+  });
+
+  it('updates a Google Sheets cast target', async () => {
+    const user = userEvent.setup();
+    const onUpdateCastType = jest.fn();
+    render(
+      <StreamSettingsPanel
+        {...baseProps}
+        columnsOpen
+        showCastColumn
+        onUpdateCastType={onUpdateCastType}
+      />
+    );
+
+    await user.click(screen.getByTestId('cast-column-survey_responses-respondent_age'));
+    await user.click(screen.getByRole('option', { name: 'Integer' }));
+
+    expect(onUpdateCastType).toHaveBeenCalledWith('survey_responses', 'respondent_age', 'integer');
+  }, 15_000);
+
+  it('keeps close available in view mode and disables every mutation control', () => {
+    render(<StreamSettingsPanel {...baseProps} columnsOpen showCastColumn disabled />);
+
+    expect(screen.getByTestId('close-stream-settings')).not.toBeDisabled();
+    expect(screen.getByTestId('stream-incremental-survey_responses')).toBeDisabled();
+    expect(screen.getByTestId('stream-destination-survey_responses')).toHaveAttribute(
+      'data-disabled'
+    );
+    expect(screen.getByTestId('col-toggle-survey_responses-respondent_age')).toBeDisabled();
+    expect(screen.getByTestId('cast-column-survey_responses-respondent_age')).toHaveAttribute(
+      'data-disabled'
+    );
+  });
+});

--- a/components/connections/connection-form-body.tsx
+++ b/components/connections/connection-form-body.tsx
@@ -33,9 +33,8 @@ import type { SyncCatalog, SchemaDiscoveryResponse } from '@/types/connections';
 import { parseCatalogStream } from './utils';
 import { useStreamConfig } from './hooks/useStreamConfig';
 import { StreamConfigTable } from './stream-config-table';
+import { StreamSettingsPanel } from './stream-settings-panel';
 import { getCustomSource } from '@/components/ingest/sources/custom/registry';
-import { ConnectionHelpPanel } from './connection-help-panel';
-import { getConnectionHelp, allowsDedup, type ConnectionConceptId } from './constants';
 
 const SCHEMA_DISCOVERY_WS_PATH = 'airbyte/connection/schema_catalog';
 
@@ -52,9 +51,8 @@ export interface ConnectionFormBodyProps {
   lockedSourceId?: string;
   onSuccess: () => void;
   onCancel: () => void;
-  // Fired when the form gains/loses its second (help) column — i.e. once streams
-  // are discovered. Lets a host (the wizard) widen its modal only after the
-  // streams table needs the room.
+  // Fired when the form gains/loses its table-settings column — i.e. once
+  // streams are discovered. Lets a host widen its modal only when needed.
   onExpandedChange?: (expanded: boolean) => void;
   // Fired once the active source resolves, so the host can name the source in the
   // modal header (and, in the wizard, show "<source> created successfully") for
@@ -145,23 +143,9 @@ export function ConnectionFormBody({
     [sourceDefName]
   );
   const showCastColumn = sourceDefName ? isCastSupportedSource(sourceDefName) : false;
-  const [activeConcept, setActiveConcept] = useState<ConnectionConceptId | null>(null);
-
-  // Help-panel cards tailored to this source's capabilities. Custom sources
-  // (Sheets/Kobo) only show the concepts that apply; everything else gets the
-  // generic full set.
-  const helpConcepts = React.useMemo(
-    () =>
-      getConnectionHelp({
-        supportsIncremental: connectionView ? connectionView.supportsIncremental : true,
-        allowsDedup: connectionView ? allowsDedup(connectionView.allowedDestModes) : true,
-        supportsColumnCasting: showCastColumn,
-      }),
-    [connectionView, showCastColumn]
-  );
+  const [activeSettingsStreamName, setActiveSettingsStreamName] = useState<string | null>(null);
 
   const [advancedOptionsOpen, setAdvancedOptionsOpen] = useState(false);
-  const [advancedStreamsOpen, setAdvancedStreamsOpen] = useState(false);
 
   const [name, setName] = useState('');
   const [destinationSchema, setDestinationSchema] = useState('staging');
@@ -179,7 +163,6 @@ export function ConnectionFormBody({
     initializeStreams,
     streamSearch,
     setStreamSearch,
-    incrementalAllStreams,
     expandedStreams,
     toggleStream,
     toggleAllStreams,
@@ -190,7 +173,6 @@ export function ConnectionFormBody({
     toggleColumn,
     updateCastType,
     toggleStreamExpand,
-    handleIncrementalAllToggle,
     filteredStreams,
     allSelected,
     hasSelectedStreams,
@@ -300,6 +282,7 @@ export function ConnectionFormBody({
   const handleSourceChange = useCallback(
     (sourceId: string) => {
       setSelectedSourceId(sourceId);
+      setActiveSettingsStreamName(null);
       initializeStreams([]);
       setDiscoveredCatalog(null);
     },
@@ -453,25 +436,43 @@ export function ConnectionFormBody({
     });
   }, [name, selectedSourceId, hasSelectedStreams]);
 
-  // Destination Schema field — shared between the always-visible (generic
-  // source) and Advanced-options-collapsed (custom source) layouts.
+  const activeSettingsStream = React.useMemo(
+    () => streams.find((stream) => stream.name === activeSettingsStreamName) ?? null,
+    [streams, activeSettingsStreamName]
+  );
+
+  useEffect(() => {
+    if (activeSettingsStreamName && !activeSettingsStream) {
+      setActiveSettingsStreamName(null);
+    }
+  }, [activeSettingsStreamName, activeSettingsStream]);
+
+  const handleOpenStreamSettings = useCallback(
+    (streamName: string) => {
+      setActiveSettingsStreamName(streamName);
+      trackEvent(ANALYTICS_EVENTS.CONNECTION_TABLE_SETTINGS_OPENED, {
+        source_type: sourceDefName,
+      });
+    },
+    [sourceDefName]
+  );
+
+  const handleCloseStreamSettings = useCallback(() => {
+    setActiveSettingsStreamName(null);
+  }, []);
+
+  // Destination Schema remains a connection-level option rather than a
+  // per-table setting, so it stays in the left-side form.
   const destinationSchemaField = (
     <div>
-      <button
-        type="button"
-        onClick={() => setActiveConcept('schema')}
-        className="cursor-pointer text-base font-medium decoration-dotted underline-offset-2 hover:underline"
-      >
-        <label htmlFor="dest-schema" className="cursor-pointer">
-          Destination Schema
-        </label>
-      </button>
+      <label htmlFor="dest-schema" className="text-base font-medium">
+        Destination Schema
+      </label>
       <Input
         id="dest-schema"
         data-testid="destination-schema-input"
         value={destinationSchema}
         onChange={(e) => setDestinationSchema(e.target.value)}
-        onFocus={() => setActiveConcept('schema')}
         placeholder="e.g., public"
         disabled={disabled || isSaving}
         className="mt-1.5"
@@ -479,7 +480,8 @@ export function ConnectionFormBody({
     </div>
   );
 
-  // Normalize uses compact inline help because it has no help-panel concept card.
+  // Normalize toggle — same sharing rationale as destinationSchemaField. This
+  // low-level option uses compact inline help rather than a full help-panel card.
   const normalizeToggleField = (
     <div className="flex items-center justify-between">
       <div className="flex items-center gap-1.5">
@@ -514,9 +516,8 @@ export function ConnectionFormBody({
     </div>
   );
 
-  // Advanced-options section (Destination Schema + Normalize behind a switch),
-  // shared by every connection. Rendered below the stream picker so the primary
-  // flow reads source → name → streams, with rarely-touched settings last.
+  // Advanced connection-level section (Destination Schema only). Normalize is
+  // important enough to remain visible, while schema stays behind disclosure.
   const advancedOptionsSection = (
     <div>
       <div className="flex items-center gap-2.5">
@@ -540,25 +541,17 @@ export function ConnectionFormBody({
           Advanced options
         </label>
       </div>
-      {advancedOptionsOpen && (
-        <div className="mt-3 space-y-6">
-          {destinationSchemaField}
-          {normalizeToggleField}
-        </div>
-      )}
+      {advancedOptionsOpen && <div className="mt-3">{destinationSchemaField}</div>}
     </div>
   );
 
-  // Docs panel only appears once discovery finishes and streams exist — avoids
-  // an empty right-hand column while the schema is still loading. Until then the
-  // form uses the full modal width (single column).
-  const showHelpPanel = streams.length > 0 && !isDiscovering;
+  const streamsReady = streams.length > 0 && !isDiscovering;
 
-  // Let the host (wizard) keep the modal compact during discovery and widen it
-  // only once the streams table + help column need the room.
+  // Once streams exist the host remains wide, so opening and closing a table's
+  // inspector does not make the modal jump between sizes.
   useEffect(() => {
-    onExpandedChange?.(showHelpPanel);
-  }, [showHelpPanel, onExpandedChange]);
+    onExpandedChange?.(streamsReady);
+  }, [streamsReady, onExpandedChange]);
 
   // Report the source name up to the host (create/edit/view) for every source, so
   // the dialog/wizard header names it — and the wizard shows "<source> created
@@ -579,9 +572,10 @@ export function ConnectionFormBody({
             height from the max-h-capped dialog — percentage height would collapse
             to auto and let the column overflow the modal instead of scrolling. */}
         <div
-          className={`grid min-h-0 flex-1 grid-cols-1 grid-rows-[minmax(0,1fr)] gap-6 ${
-            showHelpPanel ? 'md:grid-cols-[62fr_38fr]' : ''
-          }`}
+          className={cn(
+            'grid min-h-0 flex-1 grid-cols-1 grid-rows-[minmax(0,1fr)] gap-6',
+            streamsReady && 'md:grid-cols-[minmax(360px,42fr)_minmax(0,58fr)]'
+          )}
         >
           {/* The whole left column is the single scroll container: the streams
               table grows to its natural height instead of scrolling internally,
@@ -678,9 +672,8 @@ export function ConnectionFormBody({
               ) : null}
             </div>
 
-            {/* Advanced options (Destination Schema + Normalize) above the
-                stream picker, for every connection (source → name → advanced →
-                streams). */}
+            <div className="flex-shrink-0">{normalizeToggleField}</div>
+
             <div className="flex-shrink-0">{advancedOptionsSection}</div>
 
             {/* Streams region grows to its natural height; the whole left column
@@ -701,29 +694,15 @@ export function ConnectionFormBody({
                   streams={streams}
                   filteredStreams={filteredStreams}
                   allSelected={allSelected}
-                  incrementalAllStreams={incrementalAllStreams}
-                  expandedStreams={expandedStreams}
                   streamSearch={streamSearch}
                   disabled={disabled}
                   isSaving={isSaving}
+                  activeStreamName={activeSettingsStreamName}
                   onStreamSearchChange={setStreamSearch}
                   onToggleAllStreams={toggleAllStreams}
-                  onIncrementalAllToggle={handleIncrementalAllToggle}
                   onToggleStream={toggleStream}
-                  onUpdateStreamSyncMode={updateStreamSyncMode}
-                  onUpdateStreamDestMode={updateStreamDestMode}
-                  onUpdateStreamCursorField={updateStreamCursorField}
-                  onUpdateStreamPrimaryKey={updateStreamPrimaryKey}
-                  onToggleStreamExpand={toggleStreamExpand}
-                  onToggleColumn={toggleColumn}
-                  onUpdateCastType={updateCastType}
-                  showCastColumn={showCastColumn}
+                  onOpenSettings={handleOpenStreamSettings}
                   streamNoun={connectionView?.streamNoun}
-                  showIncremental={connectionView ? connectionView.supportsIncremental : true}
-                  allowedDestModes={connectionView?.allowedDestModes}
-                  onConceptFocus={setActiveConcept}
-                  advancedOpen={advancedStreamsOpen}
-                  onToggleAdvanced={() => setAdvancedStreamsOpen((o) => !o)}
                 />
               )}
 
@@ -734,21 +713,40 @@ export function ConnectionFormBody({
               )}
             </div>
           </div>
-          {/* The help panel fills the left column's height and scrolls on its
-              own, so its (tall) content never drives the modal taller than the
-              form side. Hidden until streams are discovered so the modal never
-              shows an empty docs column mid-discovery. */}
-          {showHelpPanel && (
-            <div className="relative hidden min-h-0 md:block">
-              <div className="absolute inset-0">
-                <ConnectionHelpPanel
-                  activeConcept={activeConcept}
-                  concepts={helpConcepts}
-                  onConceptChange={setActiveConcept}
-                />
+          <div className="min-h-0">
+            {activeSettingsStream ? (
+              <StreamSettingsPanel
+                stream={activeSettingsStream}
+                disabled={disabled}
+                isSaving={isSaving}
+                columnsOpen={expandedStreams.has(activeSettingsStream.name)}
+                showCastColumn={showCastColumn}
+                showIncremental={connectionView ? connectionView.supportsIncremental : true}
+                allowedDestModes={connectionView?.allowedDestModes}
+                onClose={handleCloseStreamSettings}
+                onUpdateStreamSyncMode={updateStreamSyncMode}
+                onUpdateStreamDestMode={updateStreamDestMode}
+                onUpdateStreamCursorField={updateStreamCursorField}
+                onUpdateStreamPrimaryKey={updateStreamPrimaryKey}
+                onToggleColumns={toggleStreamExpand}
+                onToggleColumn={toggleColumn}
+                onUpdateCastType={updateCastType}
+              />
+            ) : streamsReady ? (
+              <div
+                className="flex h-full min-h-[240px] items-center justify-center rounded-xl border border-dashed bg-muted/20 px-8 text-center"
+                data-testid="stream-settings-placeholder"
+              >
+                <div className="max-w-sm">
+                  <h3 className="text-base font-semibold">Choose a table to configure</h3>
+                  <p className="mt-1 text-sm leading-relaxed text-muted-foreground">
+                    Select Open settings beside a table to configure its sync method, destination,
+                    keys, and columns.
+                  </p>
+                </div>
               </div>
-            </div>
-          )}
+            ) : null}
+          </div>
         </div>
       </div>
 

--- a/components/connections/stream-config-table.tsx
+++ b/components/connections/stream-config-table.tsx
@@ -1,625 +1,158 @@
 'use client';
 
-import React from 'react';
-import { ChevronDown, SlidersHorizontal } from 'lucide-react';
+import { ChevronRight } from 'lucide-react';
 import { Input } from '@/components/ui/input';
 import { Switch } from '@/components/ui/switch';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
-import { Combobox, type ComboboxItem } from '@/components/ui/combobox';
-import { SyncMode, DestinationSyncMode, CAST_TYPE_OPTIONS } from '@/constants/connections';
+import { cn } from '@/lib/utils';
 import type { SourceStream } from '@/types/connections';
-import type { ConnectionConceptId } from './constants';
 
-// Base (always-visible) columns: stream name + sync toggle.
-const BASE_COLUMN_COUNT = 2;
-// Destination remains an advanced setting. Google Sheets exposes the separate
-// Columns control even while advanced settings are closed so users can inspect
-// detected types and configure post-sync casts without revealing unrelated
-// per-table controls.
-const ADVANCED_DESTINATION_COLUMN_COUNT = 1;
-const COLUMNS_CONTROL_COLUMN_COUNT = 1;
-// Cursor field + primary key. These are incremental-only concepts, so they show
-// only when the source supports incremental sync (e.g. hidden for Google Sheets).
-const CURSOR_PK_COLUMN_COUNT = 2;
-// Seven advanced columns need more room than the left side of the connection
-// dialog can provide. A minimum table width keeps controls readable and lets the
-// containing region scroll horizontally instead of squeezing every field.
-const FULL_ADVANCED_TABLE_WIDTH_CLASS = 'min-w-[1080px]';
-const CAST_ADVANCED_TABLE_WIDTH_CLASS = 'min-w-[760px]';
+const TABLE_TOOLS_THRESHOLD = 5;
 
 interface StreamConfigTableProps {
   streams: SourceStream[];
   filteredStreams: SourceStream[];
   allSelected: boolean;
-  incrementalAllStreams: boolean;
-  expandedStreams: Set<string>;
   streamSearch: string;
   disabled: boolean;
   isSaving: boolean;
+  activeStreamName: string | null;
   onStreamSearchChange: (value: string) => void;
   onToggleAllStreams: (selected: boolean) => void;
-  onIncrementalAllToggle: (checked: boolean) => void;
   onToggleStream: (streamName: string) => void;
-  onUpdateStreamSyncMode: (streamName: string, syncMode: string) => void;
-  onUpdateStreamDestMode: (streamName: string, destinationSyncMode: string) => void;
-  onUpdateStreamCursorField: (streamName: string, cursorField: string) => void;
-  onUpdateStreamPrimaryKey: (streamName: string, primaryKey: string[]) => void;
-  onToggleStreamExpand: (streamName: string) => void;
-  onToggleColumn: (streamName: string, columnName: string) => void;
-  onUpdateCastType: (streamName: string, columnName: string, castType: string | null) => void;
-  // Show the "Cast to" column in the expanded column view. Enabled only for
-  // sources in CAST_SUPPORTED_SOURCES (currently Google Sheets only).
-  showCastColumn?: boolean;
-  // Label used for the stream noun in headings/columns. Defaults to "Tables".
+  onOpenSettings: (streamName: string) => void;
   streamNoun?: string;
-  // Hide the Incremental column entirely (some sources never support it).
-  showIncremental?: boolean;
-  // Restrict which destination sync modes are selectable for this source.
-  allowedDestModes?: DestinationSyncMode[];
-  // Fired when a column header is clicked, to move the help panel to that concept.
-  onConceptFocus?: (id: ConnectionConceptId | null) => void;
-  // Shared advanced-settings expand bar state, owned by the parent form.
-  advancedOpen: boolean;
-  onToggleAdvanced: () => void;
 }
 
+// Keeps the table-selection task simple. Per-table configuration lives in the
+// adjacent StreamSettingsPanel instead of being compressed into this table.
 export function StreamConfigTable({
   streams,
   filteredStreams,
   allSelected,
-  incrementalAllStreams,
-  expandedStreams,
   streamSearch,
   disabled,
   isSaving,
+  activeStreamName,
   onStreamSearchChange,
   onToggleAllStreams,
-  onIncrementalAllToggle,
   onToggleStream,
-  onUpdateStreamSyncMode,
-  onUpdateStreamDestMode,
-  onUpdateStreamCursorField,
-  onUpdateStreamPrimaryKey,
-  onToggleStreamExpand,
-  onToggleColumn,
-  onUpdateCastType,
-  showCastColumn = false,
+  onOpenSettings,
   streamNoun = 'Tables',
-  showIncremental = true,
-  allowedDestModes = [
-    DestinationSyncMode.OVERWRITE,
-    DestinationSyncMode.APPEND,
-    DestinationSyncMode.APPEND_DEDUP,
-  ],
-  onConceptFocus,
-  advancedOpen,
-  onToggleAdvanced,
 }: StreamConfigTableProps) {
-  const showIncrementalColumn = advancedOpen && showIncremental;
-  // Cursor field + primary key are incremental-only; hide them for sources that
-  // don't support incremental (e.g. Google Sheets keeps only Sync + Destination).
-  const showCursorPkColumns = advancedOpen && showIncremental;
-  const showColumnsControl = advancedOpen || showCastColumn;
-  const horizontalScrollEnabled = advancedOpen && (showCursorPkColumns || showCastColumn);
-  const tableWidthClass = showCursorPkColumns
-    ? FULL_ADVANCED_TABLE_WIDTH_CLASS
-    : advancedOpen && showCastColumn
-      ? CAST_ADVANCED_TABLE_WIDTH_CLASS
-      : '';
-  // Singular, lowercased noun for inline copy: "Tables"→"table".
-  const nounSingular = streamNoun.replace(/s$/i, '').toLowerCase();
-  const selectedCount = streams.filter((s) => s.selected).length;
+  const selectedCount = streams.filter((stream) => stream.selected).length;
+  const showTableTools = streams.length > TABLE_TOOLS_THRESHOLD || streamSearch.length > 0;
 
-  // A column header that, when clicked, moves the help panel to its concept.
-  // Falls back to plain text when no help panel is wired up.
-  const conceptLabel = (label: string, concept: ConnectionConceptId) =>
-    onConceptFocus ? (
-      <button
-        type="button"
-        onClick={() => onConceptFocus(concept)}
-        className="cursor-pointer decoration-dotted underline-offset-2 hover:text-foreground hover:underline"
-        data-testid={`concept-header-${concept}`}
-      >
-        {label}
-      </button>
-    ) : (
-      <>{label}</>
-    );
-  // Incremental / Destination / Cursor / Primary Key render only when advanced
-  // is open. The Columns control is also visible for cast-capable sources so
-  // Google Sheets users can inspect types and configure casts independently.
-  const colCount =
-    BASE_COLUMN_COUNT +
-    (showIncrementalColumn ? 1 : 0) +
-    (advancedOpen ? ADVANCED_DESTINATION_COLUMN_COUNT : 0) +
-    (showCursorPkColumns ? CURSOR_PK_COLUMN_COUNT : 0) +
-    (showColumnsControl ? COLUMNS_CONTROL_COLUMN_COUNT : 0);
-
-  // Column widths per open-state, each summing to exactly 100%. The full
-  // advanced table also has a minimum width and scrolls within its container.
-  const colWidths = !advancedOpen
-    ? showColumnsControl
-      ? { stream: '72%', sync: '14%', columns: '14%' }
-      : { stream: '84%', sync: '16%' }
-    : showCursorPkColumns
-      ? {
-          stream: '22%',
-          sync: '8%',
-          incremental: '12%',
-          destination: '18%',
-          cursor: '20%',
-          pk: '11%',
-          columns: '9%',
-        }
-      : { stream: '40%', sync: '12%', destination: '38%', columns: '10%' };
   return (
-    <div className="flex flex-col">
-      {/* Header with stream count + shared advanced toggle */}
-      <div className="flex items-center justify-between">
-        <h3 className="text-base font-semibold">
-          {`Select your ${streamNoun.toLowerCase()} (${selectedCount}/${streams.length} selected)`}
-        </h3>
-        <div className="flex items-center gap-2.5 rounded-md border px-2.5 py-1.5 text-sm font-medium text-muted-foreground">
-          <SlidersHorizontal className="h-3.5 w-3.5" />
-          <label htmlFor="advanced-streams" className="cursor-pointer">
-            {`Advanced per-${nounSingular} settings`}
-          </label>
-          <Switch
-            id="advanced-streams"
-            data-testid="advanced-streams-toggle"
-            checked={advancedOpen}
-            onCheckedChange={() => onToggleAdvanced()}
-          />
-        </div>
-      </div>
-      <div className="mb-3" />
+    <section className="flex min-h-0 flex-1 flex-col" data-testid="stream-config-table">
+      <h3 className="mb-3 text-base font-semibold">
+        {`Select your ${streamNoun.toLowerCase()} (${selectedCount}/${streams.length} selected)`}
+      </h3>
 
-      {/* Table grows to its natural height; the parent left column owns the
-          scroll (overflow-y-auto), so the whole side scrolls as one and the
-          sticky header pins to the column while every row stays reachable. */}
-      <div
-        className="overflow-x-auto rounded-md border focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
-        data-testid="streams-table-scroll-container"
-        role={horizontalScrollEnabled ? 'region' : undefined}
-        aria-label={horizontalScrollEnabled ? `Advanced per-${nounSingular} settings` : undefined}
-        tabIndex={horizontalScrollEnabled ? 0 : undefined}
-      >
-        <table
-          className={`w-full table-fixed text-sm ${tableWidthClass}`}
-          data-testid="streams-table"
-        >
+      {showTableTools && (
+        <div className="mb-3 flex items-center gap-3">
+          <Input
+            placeholder={`Filter ${streamNoun.toLowerCase()}...`}
+            value={streamSearch}
+            onChange={(event) => onStreamSearchChange(event.target.value)}
+            className="h-9 flex-1 text-sm"
+            data-testid="stream-filter-input"
+          />
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <label htmlFor="toggle-all-streams">Sync all</label>
+            <Switch
+              id="toggle-all-streams"
+              checked={allSelected}
+              onCheckedChange={(checked) => onToggleAllStreams(checked)}
+              disabled={disabled || isSaving}
+              data-testid="toggle-all-streams"
+            />
+          </div>
+        </div>
+      )}
+
+      <div className="min-h-0 overflow-y-auto rounded-lg border">
+        <table className="w-full table-fixed text-sm" data-testid="streams-table">
           <colgroup>
-            <col style={{ width: colWidths.stream }} />
-            <col style={{ width: colWidths.sync }} />
-            {showIncrementalColumn && <col style={{ width: colWidths.incremental }} />}
-            {advancedOpen && <col style={{ width: colWidths.destination }} />}
-            {showCursorPkColumns && (
-              <>
-                <col style={{ width: colWidths.cursor }} />
-                <col style={{ width: colWidths.pk }} />
-              </>
-            )}
-            {showColumnsControl && <col style={{ width: colWidths.columns }} />}
+            <col className="w-[50%]" />
+            <col className="w-[18%]" />
+            <col className="w-[32%]" />
           </colgroup>
-          <thead className="sticky top-0 z-10">
-            <tr className="border-b bg-muted">
-              <th className="px-3 py-2 text-left text-sm font-medium text-muted-foreground">
-                {conceptLabel(streamNoun, 'stream')}
-              </th>
-              <th className="px-3 py-2 text-center text-sm font-medium text-muted-foreground">
-                {conceptLabel('Sync?', 'sync')}
-              </th>
-              {showIncrementalColumn && (
-                <th className="px-3 py-2 text-center text-sm font-medium text-muted-foreground">
-                  {conceptLabel('Incremental?', 'sync-mode')}
-                </th>
-              )}
-              {advancedOpen && (
-                <th className="px-3 py-2 text-left text-sm font-medium text-muted-foreground">
-                  {conceptLabel('Destination', 'dest-mode')}
-                </th>
-              )}
-              {showCursorPkColumns && (
-                <>
-                  <th className="px-3 py-2 text-left text-sm font-medium text-muted-foreground">
-                    {conceptLabel('Cursor Field', 'cursor')}
-                  </th>
-                  <th className="px-3 py-2 text-left text-sm font-medium text-muted-foreground">
-                    {conceptLabel('Primary Key', 'primary-key')}
-                  </th>
-                </>
-              )}
-              {showColumnsControl && (
-                <th className="px-3 py-2 text-center text-sm font-medium text-muted-foreground">
-                  {conceptLabel('Columns', 'columns')}
-                </th>
-              )}
-            </tr>
-            {/* Global toggle row */}
-            <tr className="border-b bg-muted">
-              <td className="px-3 py-1.5">
-                <Input
-                  placeholder="Filter..."
-                  value={streamSearch}
-                  onChange={(e) => onStreamSearchChange(e.target.value)}
-                  className="w-full max-w-[260px] h-8 text-sm"
-                  data-testid="stream-filter-input"
-                />
-              </td>
-              <td className="px-3 py-1.5 text-center">
-                <Switch
-                  checked={allSelected}
-                  onCheckedChange={onToggleAllStreams}
-                  disabled={disabled || isSaving}
-                  data-testid="toggle-all-streams"
-                  className="scale-90"
-                />
-              </td>
-              {showIncrementalColumn && (
-                <td className="px-3 py-1.5 text-center">
-                  <Switch
-                    checked={incrementalAllStreams}
-                    onCheckedChange={onIncrementalAllToggle}
-                    disabled={disabled || isSaving || !allSelected}
-                    data-testid="toggle-incremental-all"
-                    className="scale-90"
-                  />
-                </td>
-              )}
-              {advancedOpen && <td className="px-3 py-1.5" />}
-              {showCursorPkColumns && (
-                <>
-                  <td className="px-3 py-1.5" />
-                  <td className="px-3 py-1.5" />
-                </>
-              )}
-              {showColumnsControl && <td className="px-3 py-1.5" />}
+          <thead className="sticky top-0 z-10 bg-background">
+            <tr className="border-b text-muted-foreground">
+              <th className="px-4 py-3 text-left text-sm font-medium">{streamNoun}</th>
+              <th className="px-3 py-3 text-center text-sm font-medium">Sync</th>
+              <th className="px-4 py-3 text-left text-sm font-medium">Advanced settings</th>
             </tr>
           </thead>
           <tbody>
             {filteredStreams.map((stream) => {
-              const isIncremental = stream.syncMode === SyncMode.INCREMENTAL;
-              const cursorOptions = stream.cursorFieldConfig?.all || [];
-              const primaryKeyOptions = stream.primaryKeyConfig?.all || [];
-
-              // Build combobox items for cursor field
-              const cursorItems: ComboboxItem[] = (
-                Array.isArray(cursorOptions[0])
-                  ? cursorOptions.map((o: string | string[]) => (Array.isArray(o) ? o[0] : o))
-                  : cursorOptions
-              ).map((field: string) => ({
-                value: field,
-                label: field,
-              }));
-
-              // Build combobox items for primary key
-              const pkItems: ComboboxItem[] = primaryKeyOptions.map((pk: string | string[]) => {
-                const val = Array.isArray(pk) ? pk[0] : pk;
-                return { value: val, label: val };
-              });
-
-              const isSelected = stream.selected;
-              const isIncrementalChecked =
-                stream.supportsIncremental && isIncremental && isSelected;
-
-              // Determine why cursor field is disabled (for tooltip)
-              const cursorDisabled =
-                disabled ||
-                isSaving ||
-                !isSelected ||
-                !stream.supportsIncremental ||
-                !isIncremental ||
-                !!stream.cursorFieldConfig?.sourceDefinedCursor;
-              const cursorDisabledReason = !isSelected
-                ? `Enable sync for this ${nounSingular} first`
-                : !stream.supportsIncremental
-                  ? 'This source does not support incremental sync'
-                  : !isIncremental
-                    ? 'Switch to incremental sync mode to set a cursor field'
-                    : stream.cursorFieldConfig?.sourceDefinedCursor
-                      ? 'Cursor field is defined by the source and cannot be changed'
-                      : '';
-
-              // Determine why primary key is disabled (for tooltip)
-              const pkDisabled =
-                disabled ||
-                isSaving ||
-                !isSelected ||
-                !stream.supportsIncremental ||
-                !isIncremental ||
-                stream.destinationSyncMode !== DestinationSyncMode.APPEND_DEDUP ||
-                !!stream.primaryKeyConfig?.sourceDefinedPrimaryKey;
-              const pkDisabledReason = !isSelected
-                ? `Enable sync for this ${nounSingular} first`
-                : !stream.supportsIncremental
-                  ? 'This source does not support incremental sync'
-                  : !isIncremental
-                    ? 'Switch to incremental sync mode to set a primary key'
-                    : stream.destinationSyncMode !== DestinationSyncMode.APPEND_DEDUP
-                      ? 'Set destination mode to Append / Dedup to configure a primary key'
-                      : stream.primaryKeyConfig?.sourceDefinedPrimaryKey
-                        ? 'Primary key is defined by the source and cannot be changed'
-                        : '';
-
+              const isActive = activeStreamName === stream.name;
               return (
-                <React.Fragment key={stream.name}>
-                  <tr
-                    className="border-b last:border-b-0"
-                    data-testid={`stream-row-${stream.name}`}
-                  >
-                    {/* Stream name */}
-                    <td className="px-3 py-3">
-                      <TooltipProvider>
-                        <Tooltip>
-                          <TooltipTrigger asChild>
-                            <span className="inline-block max-w-full truncate align-middle text-sm font-medium text-foreground">
-                              {stream.name}
-                            </span>
-                          </TooltipTrigger>
-                          <TooltipContent side="top" className="max-w-xs break-all">
-                            <p className="text-xs">{stream.name}</p>
-                          </TooltipContent>
-                        </Tooltip>
-                      </TooltipProvider>
-                    </td>
-                    {/* Sync toggle */}
-                    <td className="px-3 py-3 text-center">
-                      <Switch
-                        checked={isSelected}
-                        onCheckedChange={() => onToggleStream(stream.name)}
-                        disabled={disabled || isSaving}
-                        data-testid={`stream-toggle-${stream.name}`}
-                        className="scale-90"
-                      />
-                    </td>
-                    {/* Incremental toggle */}
-                    {showIncrementalColumn && (
-                      <td className="px-3 py-3 text-center">
-                        <Switch
-                          checked={isIncrementalChecked}
-                          onCheckedChange={(checked) => {
-                            onUpdateStreamSyncMode(
-                              stream.name,
-                              checked ? SyncMode.INCREMENTAL : SyncMode.FULL_REFRESH
-                            );
-                          }}
-                          disabled={
-                            disabled || isSaving || !isSelected || !stream.supportsIncremental
-                          }
-                          data-testid={`stream-incremental-${stream.name}`}
-                          className="scale-90"
-                        />
-                      </td>
-                    )}
-                    {/* Destination mode */}
-                    {advancedOpen && (
-                      <td className="px-3 py-3">
-                        <Select
-                          value={stream.destinationSyncMode}
-                          onValueChange={(v) => onUpdateStreamDestMode(stream.name, v)}
-                          disabled={disabled || isSaving || !isSelected}
-                        >
-                          <SelectTrigger className="h-8 text-sm w-full">
-                            <SelectValue />
-                          </SelectTrigger>
-                          <SelectContent>
-                            {allowedDestModes.includes(DestinationSyncMode.OVERWRITE) && (
-                              <SelectItem
-                                value={DestinationSyncMode.OVERWRITE}
-                                disabled={isIncremental}
-                              >
-                                Overwrite
-                              </SelectItem>
-                            )}
-                            {allowedDestModes.includes(DestinationSyncMode.APPEND) && (
-                              <SelectItem value={DestinationSyncMode.APPEND}>Append</SelectItem>
-                            )}
-                            {allowedDestModes.includes(DestinationSyncMode.APPEND_DEDUP) && (
-                              <SelectItem value={DestinationSyncMode.APPEND_DEDUP}>
-                                Append / Dedup
-                              </SelectItem>
-                            )}
-                          </SelectContent>
-                        </Select>
-                      </td>
-                    )}
-                    {/* Cursor Field + Primary Key — incremental-only, hidden for
-                        sources without incremental support (e.g. Google Sheets) */}
-                    {showCursorPkColumns && (
-                      <>
-                        <td className="px-3 py-3 overflow-visible">
-                          <TooltipProvider>
-                            <Tooltip>
-                              <TooltipTrigger asChild>
-                                <div>
-                                  <Combobox
-                                    mode="single"
-                                    items={cursorItems}
-                                    value={stream.cursorField || ''}
-                                    onValueChange={(v) => onUpdateStreamCursorField(stream.name, v)}
-                                    disabled={cursorDisabled}
-                                    placeholder="Select..."
-                                    searchPlaceholder="Search..."
-                                    compact
-                                    id={`cursor-${stream.name}`}
-                                    className="w-full"
-                                  />
-                                </div>
-                              </TooltipTrigger>
-                              {cursorDisabled && cursorDisabledReason && (
-                                <TooltipContent side="top">
-                                  <p className="text-xs">{cursorDisabledReason}</p>
-                                </TooltipContent>
-                              )}
-                            </Tooltip>
-                          </TooltipProvider>
-                        </td>
-                        {/* Primary Key — always show, disabled when not incremental+append_dedup */}
-                        <td className="px-3 py-3 overflow-visible">
-                          <TooltipProvider>
-                            <Tooltip>
-                              <TooltipTrigger asChild>
-                                <div>
-                                  <Combobox
-                                    mode="multi"
-                                    items={pkItems}
-                                    values={stream.primaryKey || []}
-                                    onValuesChange={(vals) =>
-                                      onUpdateStreamPrimaryKey(stream.name, vals)
-                                    }
-                                    disabled={pkDisabled}
-                                    searchPlaceholder="Select keys..."
-                                    compact
-                                    id={`pk-${stream.name}`}
-                                    triggerClassName="h-8 !min-h-0 !flex-nowrap overflow-hidden"
-                                    className="w-full"
-                                  />
-                                </div>
-                              </TooltipTrigger>
-                              {pkDisabled && pkDisabledReason && (
-                                <TooltipContent side="top">
-                                  <p className="text-xs">{pkDisabledReason}</p>
-                                </TooltipContent>
-                              )}
-                            </Tooltip>
-                          </TooltipProvider>
-                        </td>
-                      </>
-                    )}
-                    {/* Column expand */}
-                    {showColumnsControl && (
-                      <td className="px-1 py-3 text-center">
-                        {stream.columns.length > 0 && (
-                          <button
-                            type="button"
-                            onClick={() => isSelected && onToggleStreamExpand(stream.name)}
-                            disabled={!isSelected}
-                            className="p-1 hover:bg-gray-100 rounded cursor-pointer disabled:opacity-30 disabled:cursor-default"
-                            data-testid={`expand-columns-${stream.name}`}
-                            aria-label={`${expandedStreams.has(stream.name) ? 'Hide' : 'Show'} columns for ${stream.name}`}
-                            aria-expanded={expandedStreams.has(stream.name)}
-                          >
-                            <ChevronDown
-                              className={`h-4 w-4 text-gray-500 transition-transform ${
-                                expandedStreams.has(stream.name) ? 'rotate-180' : ''
-                              }`}
-                            />
-                          </button>
-                        )}
-                      </td>
-                    )}
-                  </tr>
-                  {/* Expanded column selection — vertical list */}
-                  {showColumnsControl &&
-                    expandedStreams.has(stream.name) &&
-                    isSelected &&
-                    stream.columns.length > 0 && (
-                      <tr key={`cols-${stream.name}`} className="bg-muted/30">
-                        <td colSpan={colCount} className="px-4 py-2">
-                          <table className="w-full">
-                            <thead>
-                              <tr className="border-b border-muted">
-                                <th className="py-1 px-2 w-10" />
-                                <th className="py-1 px-2 text-left text-xs font-medium text-muted-foreground">
-                                  Column
-                                </th>
-                                <th className="py-1 px-2 text-right text-xs font-medium text-muted-foreground">
-                                  Type
-                                </th>
-                                {showCastColumn && (
-                                  <th className="py-1 px-2 text-right text-xs font-medium text-muted-foreground w-36">
-                                    Cast to
-                                  </th>
-                                )}
-                              </tr>
-                            </thead>
-                            <tbody>
-                              {stream.columns.map((col) => {
-                                const isCursorField = stream.cursorField === col.name;
-                                const isPrimaryKey = stream.primaryKey?.includes(col.name);
-                                const isProtected = isCursorField || isPrimaryKey;
-
-                                return (
-                                  <tr
-                                    key={col.name}
-                                    className="border-b last:border-b-0 border-muted"
-                                  >
-                                    <td className="py-1.5 px-2 w-10">
-                                      <Switch
-                                        checked={col.selected}
-                                        onCheckedChange={() =>
-                                          onToggleColumn(stream.name, col.name)
-                                        }
-                                        disabled={disabled || isSaving || isProtected}
-                                        className="scale-75"
-                                        data-testid={`col-toggle-${stream.name}-${col.name}`}
-                                      />
-                                    </td>
-                                    <td className="py-1.5 px-2">
-                                      <span
-                                        className={`text-xs ${
-                                          isProtected ? 'text-muted-foreground' : 'text-foreground'
-                                        }`}
-                                      >
-                                        {col.name}
-                                      </span>
-                                    </td>
-                                    <td className="py-1.5 px-2 text-right">
-                                      <span className="text-xs text-muted-foreground">
-                                        {col.data_type}
-                                      </span>
-                                    </td>
-                                    {showCastColumn && (
-                                      <td className="py-1.5 px-2 text-right w-36">
-                                        <Select
-                                          value={col.cast_to_type ?? undefined}
-                                          onValueChange={(v) =>
-                                            onUpdateCastType(
-                                              stream.name,
-                                              col.name,
-                                              v === '__none__' ? null : v
-                                            )
-                                          }
-                                          disabled={disabled || isSaving || !col.selected}
-                                        >
-                                          <SelectTrigger
-                                            className="h-6 text-xs w-full"
-                                            data-testid={`cast-type-${stream.name}-${col.name}`}
-                                          >
-                                            <SelectValue placeholder="—" />
-                                          </SelectTrigger>
-                                          <SelectContent>
-                                            <SelectItem value="__none__">—</SelectItem>
-                                            {CAST_TYPE_OPTIONS.map((opt) => (
-                                              <SelectItem key={opt.value} value={opt.value}>
-                                                {opt.label}
-                                              </SelectItem>
-                                            ))}
-                                          </SelectContent>
-                                        </Select>
-                                      </td>
-                                    )}
-                                  </tr>
-                                );
-                              })}
-                            </tbody>
-                          </table>
-                        </td>
-                      </tr>
-                    )}
-                </React.Fragment>
+                <tr
+                  key={stream.name}
+                  data-testid={`stream-row-${stream.name}`}
+                  data-active={isActive}
+                  className={cn(
+                    'border-b last:border-b-0 transition-colors',
+                    isActive
+                      ? 'border-l-2 border-l-primary bg-primary/5'
+                      : 'border-l-2 border-l-transparent'
+                  )}
+                >
+                  <td className="px-4 py-4">
+                    <TooltipProvider>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <span className="block truncate text-sm font-medium text-foreground">
+                            {stream.name}
+                          </span>
+                        </TooltipTrigger>
+                        <TooltipContent side="top" className="max-w-xs break-all">
+                          <p className="text-xs">{stream.name}</p>
+                        </TooltipContent>
+                      </Tooltip>
+                    </TooltipProvider>
+                  </td>
+                  <td className="px-3 py-4 text-center">
+                    <Switch
+                      id={`stream-toggle-${stream.name}`}
+                      checked={stream.selected}
+                      onCheckedChange={() => onToggleStream(stream.name)}
+                      disabled={disabled || isSaving}
+                      aria-label={`Sync ${stream.name}`}
+                      data-testid={`stream-toggle-${stream.name}`}
+                      className="scale-90"
+                    />
+                  </td>
+                  <td className="px-4 py-4">
+                    <button
+                      type="button"
+                      onClick={() => onOpenSettings(stream.name)}
+                      aria-label={`Open advanced settings for ${stream.name}`}
+                      aria-pressed={isActive}
+                      data-testid={`open-stream-settings-${stream.name}`}
+                      className={cn(
+                        'inline-flex min-h-8 items-center gap-1 rounded-sm px-1 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+                        isActive ? 'text-primary' : 'text-foreground hover:text-primary'
+                      )}
+                    >
+                      Open settings
+                      <ChevronRight className="h-4 w-4" aria-hidden="true" />
+                    </button>
+                  </td>
+                </tr>
               );
             })}
           </tbody>
         </table>
+
+        {filteredStreams.length === 0 && (
+          <p className="px-4 py-8 text-center text-sm text-muted-foreground">
+            No {streamNoun.toLowerCase()} match your search.
+          </p>
+        )}
       </div>
-    </div>
+    </section>
   );
 }

--- a/components/connections/stream-settings-panel.tsx
+++ b/components/connections/stream-settings-panel.tsx
@@ -1,0 +1,377 @@
+'use client';
+
+import { ChevronDown, ChevronLeft } from 'lucide-react';
+import type { ReactNode } from 'react';
+import { Switch } from '@/components/ui/switch';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Combobox, type ComboboxItem } from '@/components/ui/combobox';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+import { cn } from '@/lib/utils';
+import { CAST_TYPE_OPTIONS, DestinationSyncMode, SyncMode } from '@/constants/connections';
+import type { SourceStream } from '@/types/connections';
+
+interface StreamSettingsPanelProps {
+  stream: SourceStream;
+  disabled: boolean;
+  isSaving: boolean;
+  columnsOpen: boolean;
+  showCastColumn?: boolean;
+  showIncremental?: boolean;
+  allowedDestModes?: DestinationSyncMode[];
+  onClose: () => void;
+  onUpdateStreamSyncMode: (streamName: string, syncMode: string) => void;
+  onUpdateStreamDestMode: (streamName: string, destinationSyncMode: string) => void;
+  onUpdateStreamCursorField: (streamName: string, cursorField: string) => void;
+  onUpdateStreamPrimaryKey: (streamName: string, primaryKey: string[]) => void;
+  onToggleColumns: (streamName: string) => void;
+  onToggleColumn: (streamName: string, columnName: string) => void;
+  onUpdateCastType: (streamName: string, columnName: string, castType: string | null) => void;
+}
+
+interface SettingsRowProps {
+  label: string;
+  description: string;
+  children: ReactNode;
+}
+
+function SettingsRow({ label, description, children }: SettingsRowProps) {
+  return (
+    <div className="grid gap-3 border-b px-5 py-5 lg:grid-cols-[140px_minmax(180px,230px)_minmax(220px,1fr)] lg:items-center">
+      <p className="text-sm font-medium text-foreground">{label}</p>
+      <div>{children}</div>
+      <p className="text-sm leading-relaxed text-muted-foreground">{description}</p>
+    </div>
+  );
+}
+
+export function StreamSettingsPanel({
+  stream,
+  disabled,
+  isSaving,
+  columnsOpen,
+  showCastColumn = false,
+  showIncremental = true,
+  allowedDestModes = [
+    DestinationSyncMode.OVERWRITE,
+    DestinationSyncMode.APPEND,
+    DestinationSyncMode.APPEND_DEDUP,
+  ],
+  onClose,
+  onUpdateStreamSyncMode,
+  onUpdateStreamDestMode,
+  onUpdateStreamCursorField,
+  onUpdateStreamPrimaryKey,
+  onToggleColumns,
+  onToggleColumn,
+  onUpdateCastType,
+}: StreamSettingsPanelProps) {
+  const isIncremental = stream.syncMode === SyncMode.INCREMENTAL;
+  const isBusy = disabled || isSaving || !stream.selected;
+  const cursorOptions = stream.cursorFieldConfig?.all ?? [];
+  const primaryKeyOptions = stream.primaryKeyConfig?.all ?? [];
+
+  const cursorItems: ComboboxItem[] = (
+    Array.isArray(cursorOptions[0])
+      ? cursorOptions.map((option: string | string[]) =>
+          Array.isArray(option) ? option[0] : option
+        )
+      : cursorOptions
+  ).map((field: string) => ({ value: field, label: field }));
+
+  const primaryKeyItems: ComboboxItem[] = primaryKeyOptions.map((option: string | string[]) => {
+    const field = Array.isArray(option) ? option[0] : option;
+    return { value: field, label: field };
+  });
+
+  const cursorDisabled =
+    isBusy ||
+    !stream.supportsIncremental ||
+    !isIncremental ||
+    !!stream.cursorFieldConfig?.sourceDefinedCursor;
+  const cursorDisabledReason = !stream.supportsIncremental
+    ? 'This source does not support incremental sync'
+    : !isIncremental
+      ? 'Turn on incremental sync first'
+      : stream.cursorFieldConfig?.sourceDefinedCursor
+        ? 'The source defines this cursor field'
+        : '';
+
+  const primaryKeyDisabled =
+    isBusy ||
+    !stream.supportsIncremental ||
+    !isIncremental ||
+    stream.destinationSyncMode !== DestinationSyncMode.APPEND_DEDUP ||
+    !!stream.primaryKeyConfig?.sourceDefinedPrimaryKey;
+  const primaryKeyDisabledReason = !isIncremental
+    ? 'Turn on incremental sync first'
+    : stream.destinationSyncMode !== DestinationSyncMode.APPEND_DEDUP
+      ? 'Choose Append + Dedup first'
+      : stream.primaryKeyConfig?.sourceDefinedPrimaryKey
+        ? 'The source defines this primary key'
+        : '';
+
+  const selectedColumnCount = stream.columns.filter((column) => column.selected).length;
+
+  return (
+    <aside
+      className="flex h-full min-h-0 flex-col overflow-hidden rounded-xl border bg-background"
+      data-testid="stream-settings-panel"
+    >
+      <div className="flex flex-shrink-0 items-start gap-3 border-b px-5 py-4">
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="Close advanced settings"
+          data-testid="close-stream-settings"
+          className="mt-0.5 inline-flex size-8 flex-shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          <ChevronLeft className="h-5 w-5" aria-hidden="true" />
+        </button>
+        <div className="min-w-0">
+          <h3 className="text-lg font-semibold text-foreground">Advanced settings</h3>
+          <p className="truncate text-sm text-muted-foreground" data-testid="settings-stream-name">
+            {stream.name}
+          </p>
+        </div>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-y-auto" data-testid="stream-settings-scroll-area">
+        {showIncremental && (
+          <SettingsRow
+            label="Incremental"
+            description="Only bring in records added or changed since the last sync."
+          >
+            <Switch
+              id={`stream-incremental-${stream.name}`}
+              checked={stream.supportsIncremental && isIncremental}
+              onCheckedChange={(checked) =>
+                onUpdateStreamSyncMode(
+                  stream.name,
+                  checked ? SyncMode.INCREMENTAL : SyncMode.FULL_REFRESH
+                )
+              }
+              disabled={isBusy || !stream.supportsIncremental}
+              aria-label={`Use incremental sync for ${stream.name}`}
+              data-testid={`stream-incremental-${stream.name}`}
+            />
+          </SettingsRow>
+        )}
+
+        <SettingsRow
+          label="Destination"
+          description="Choose whether new data is added or replaces the existing table."
+        >
+          <Select
+            value={stream.destinationSyncMode}
+            onValueChange={(value) => onUpdateStreamDestMode(stream.name, value)}
+            disabled={isBusy}
+          >
+            <SelectTrigger
+              id={`stream-destination-${stream.name}`}
+              className="h-9 w-full text-sm"
+              aria-label={`Destination mode for ${stream.name}`}
+              data-testid={`stream-destination-${stream.name}`}
+            >
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {allowedDestModes.includes(DestinationSyncMode.OVERWRITE) && (
+                <SelectItem value={DestinationSyncMode.OVERWRITE} disabled={isIncremental}>
+                  Overwrite
+                </SelectItem>
+              )}
+              {allowedDestModes.includes(DestinationSyncMode.APPEND) && (
+                <SelectItem value={DestinationSyncMode.APPEND}>Append</SelectItem>
+              )}
+              {allowedDestModes.includes(DestinationSyncMode.APPEND_DEDUP) && (
+                <SelectItem value={DestinationSyncMode.APPEND_DEDUP}>Append + Dedup</SelectItem>
+              )}
+            </SelectContent>
+          </Select>
+        </SettingsRow>
+
+        {showIncremental && (
+          <>
+            <SettingsRow
+              label="Cursor field"
+              description="The field Dalgo uses to identify newer records."
+            >
+              <TooltipProvider>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <div>
+                      <Combobox
+                        mode="single"
+                        items={cursorItems}
+                        value={stream.cursorField || ''}
+                        onValueChange={(value) => onUpdateStreamCursorField(stream.name, value)}
+                        disabled={cursorDisabled}
+                        placeholder="Select field"
+                        searchPlaceholder="Search fields..."
+                        compact
+                        id={`cursor-${stream.name}`}
+                        className="w-full"
+                      />
+                    </div>
+                  </TooltipTrigger>
+                  {cursorDisabled && cursorDisabledReason && (
+                    <TooltipContent side="top">
+                      <p className="text-xs">{cursorDisabledReason}</p>
+                    </TooltipContent>
+                  )}
+                </Tooltip>
+              </TooltipProvider>
+            </SettingsRow>
+
+            <SettingsRow
+              label="Primary key"
+              description="The field that uniquely identifies each record."
+            >
+              <TooltipProvider>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <div>
+                      <Combobox
+                        mode="multi"
+                        items={primaryKeyItems}
+                        values={stream.primaryKey ?? []}
+                        onValuesChange={(values) => onUpdateStreamPrimaryKey(stream.name, values)}
+                        disabled={primaryKeyDisabled}
+                        searchPlaceholder="Select keys..."
+                        compact
+                        id={`pk-${stream.name}`}
+                        triggerClassName="h-9 !min-h-0 !flex-nowrap overflow-hidden"
+                        className="w-full"
+                      />
+                    </div>
+                  </TooltipTrigger>
+                  {primaryKeyDisabled && primaryKeyDisabledReason && (
+                    <TooltipContent side="top">
+                      <p className="text-xs">{primaryKeyDisabledReason}</p>
+                    </TooltipContent>
+                  )}
+                </Tooltip>
+              </TooltipProvider>
+            </SettingsRow>
+          </>
+        )}
+
+        <div>
+          <button
+            type="button"
+            onClick={() => onToggleColumns(stream.name)}
+            aria-expanded={columnsOpen}
+            aria-controls={`stream-columns-${stream.name}`}
+            data-testid={`toggle-stream-columns-${stream.name}`}
+            className="grid w-full gap-3 border-b px-5 py-5 text-left hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring lg:grid-cols-[140px_minmax(180px,230px)_minmax(220px,1fr)] lg:items-center"
+          >
+            <span className="text-sm font-medium text-foreground">Columns</span>
+            <span className="flex items-center justify-between gap-3 text-sm text-foreground">
+              {selectedColumnCount} selected
+              <ChevronDown
+                className={cn(
+                  'h-4 w-4 flex-shrink-0 text-muted-foreground transition-transform',
+                  columnsOpen && 'rotate-180'
+                )}
+                aria-hidden="true"
+              />
+            </span>
+            <span className="text-sm leading-relaxed text-muted-foreground">
+              Choose which source fields arrive in your warehouse.
+            </span>
+          </button>
+
+          {columnsOpen && (
+            <div id={`stream-columns-${stream.name}`} className="px-5 pb-5">
+              {showCastColumn && (
+                <p className="mb-3 mt-4 text-xs leading-relaxed text-muted-foreground">
+                  Cast to converts the value in your warehouse after each sync. Leave it blank to
+                  keep the detected type.
+                </p>
+              )}
+              <div className="overflow-x-auto rounded-md border">
+                <table className="w-full min-w-[540px] text-sm">
+                  <thead>
+                    <tr className="border-b bg-muted/50 text-muted-foreground">
+                      <th className="w-20 px-3 py-2 text-left text-xs font-medium">Include</th>
+                      <th className="px-3 py-2 text-left text-xs font-medium">Column</th>
+                      <th className="w-32 px-3 py-2 text-left text-xs font-medium">Type</th>
+                      {showCastColumn && (
+                        <th className="w-40 px-3 py-2 text-left text-xs font-medium">Cast to</th>
+                      )}
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {stream.columns.map((column) => {
+                      const isProtected =
+                        stream.cursorField === column.name ||
+                        stream.primaryKey?.includes(column.name);
+                      return (
+                        <tr key={column.name} className="border-b last:border-b-0">
+                          <td className="px-3 py-2.5">
+                            <Switch
+                              id={`column-${stream.name}-${column.name}`}
+                              checked={column.selected}
+                              onCheckedChange={() => onToggleColumn(stream.name, column.name)}
+                              disabled={isBusy || isProtected}
+                              aria-label={`Include ${column.name}`}
+                              data-testid={`col-toggle-${stream.name}-${column.name}`}
+                              className="scale-75"
+                            />
+                          </td>
+                          <td className="max-w-[260px] truncate px-3 py-2.5 text-xs font-medium">
+                            {column.name}
+                          </td>
+                          <td className="px-3 py-2.5 text-xs text-muted-foreground">
+                            {column.data_type}
+                          </td>
+                          {showCastColumn && (
+                            <td className="px-3 py-2">
+                              <Select
+                                value={column.cast_to_type ?? '__none__'}
+                                onValueChange={(value) =>
+                                  onUpdateCastType(
+                                    stream.name,
+                                    column.name,
+                                    value === '__none__' ? null : value
+                                  )
+                                }
+                                disabled={isBusy || !column.selected}
+                              >
+                                <SelectTrigger
+                                  className="h-8 w-full text-xs"
+                                  aria-label={`Cast ${column.name} to`}
+                                  data-testid={`cast-column-${stream.name}-${column.name}`}
+                                >
+                                  <SelectValue placeholder="Keep detected type" />
+                                </SelectTrigger>
+                                <SelectContent>
+                                  <SelectItem value="__none__">Keep detected type</SelectItem>
+                                  {CAST_TYPE_OPTIONS.map((option) => (
+                                    <SelectItem key={option.value} value={option.value}>
+                                      {option.label}
+                                    </SelectItem>
+                                  ))}
+                                </SelectContent>
+                              </Select>
+                            </td>
+                          )}
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </aside>
+  );
+}

--- a/constants/analytics.ts
+++ b/constants/analytics.ts
@@ -145,6 +145,7 @@ export const ANALYTICS_EVENTS = {
   CONNECTION_SCHEMA_CHANGES_APPLIED: 'connection:schema_changes_applied',
   CONNECTION_LOG_SUMMARY_REQUESTED: 'connection:log_summary_requested',
   CONNECTION_ADVANCED_OPTIONS_EXPANDED: 'connection:advanced_options_expanded',
+  CONNECTION_TABLE_SETTINGS_OPENED: 'connection:table_settings_opened',
   SOURCE_CREATED: 'source:source_created',
   SOURCE_UPDATED: 'source:source_updated',
   SOURCE_DELETED: 'source:source_deleted',

--- a/design-qa.md
+++ b/design-qa.md
@@ -1,0 +1,48 @@
+# DALGO-1625 two-pane table settings — design QA
+
+- Source visual truth: `/Users/pratiksharao/.codex/generated_images/019ff004-8119-7f12-8173-4c4c9197af53/exec-dc932e27-db3a-44c5-bc8c-218ba123f448.png`
+- Browser-rendered implementation: `/private/tmp/dalgo-inspector-implementation.png`
+- Full-view comparison: `/private/tmp/dalgo-inspector-comparison.png`
+- Focused panel comparison: `/private/tmp/dalgo-inspector-focused-comparison.png`
+- Route: `http://localhost:3001/ingest`
+- State: Edit `Audit Kobo Sync` → open `survey_responses` settings → expand Columns
+- Browser viewport / CSS size: 1676 × 927 at device scale 1
+- Source pixels: 1686 × 933
+- Implementation pixels: 1676 × 927
+- Normalization: the source was scaled to 1676 × 927 before the full-view comparison. The focused comparison crops the advanced-settings regions and normalizes their widths.
+
+## Findings
+
+No actionable P0, P1, or P2 visual differences remain.
+
+- Typography: Dalgo's existing font, weights, compact labels, and heading hierarchy are preserved. The implementation is slightly denser than the concept image, which is acceptable because it follows the production design system and leaves more usable space for long schemas.
+- Spacing and layout: the approved left-table/right-inspector composition is present; the settings panel remains bounded; controls, descriptions, and columns align in consistent rows; the inspector scrolls independently.
+- Colors and tokens: implementation uses existing Dalgo foreground, border, muted, and primary tokens. The selected row and switches retain native Dalgo states rather than introducing mock-specific colors.
+- Image quality: no raster or decorative image assets are part of this UI. Existing Lucide icons and native controls remain sharp.
+- Copy: labels match table concepts, Sync appears only on the left, each right-side setting has one plain-language explanation, and Columns expands downward to show Include, Column, and Type.
+- Accessibility and interaction: the inspector close control, active settings row, Columns expanded state, Sync switches, and form controls have spoken names. Opening/closing the panel and expanding Columns were exercised in the browser.
+- Console: no browser console errors were present in the verified state.
+
+## Google Sheets cast verification
+
+The local visible fixture is KoboToolbox, so it correctly does not render a Cast to column. Google Sheets-specific rendering and selection were verified through focused component/integration tests: the form passes `showCastColumn=true` only for Google Sheets, the expanded Columns table renders Cast to, selecting Integer calls the existing cast updater, and save preserves the existing `post_sync_transform` payload.
+
+## Comparison history
+
+Pass 1 found no P0/P1/P2 mismatch. No visual fixes were required after the normalized full-view and focused-region comparisons.
+
+## Primary interactions tested
+
+1. Open Edit for the existing Kobo connection.
+2. Open `survey_responses` Advanced settings.
+3. Confirm Sync remains only in the left table.
+4. Expand Columns downward.
+5. Confirm Include, Column, and Type rows render inside the scrollable inspector.
+6. Confirm the panel stays inside the modal at 1676 × 927.
+
+## Follow-up polish
+
+- P3: the mock uses square checkboxes for column inclusion while Dalgo's existing implementation uses switches. Keeping the native switch is deliberate for consistency.
+- P3: the local fixture contains one table and five columns, whereas the mock shows two tables and 42 columns. This changes content density but not the implemented layout or behavior.
+
+final result: passed


### PR DESCRIPTION
## Summary

This PR separates per-table Ingest configuration from the stream-selection table. The left side stays focused on choosing tables and controlling Sync, while **Open settings** reveals a dedicated inspector for the selected table.

| Work item | What changed | How to test in the UI |
| --- | --- | --- |
| [DALGO-1625](https://linear.app/dalgo/issue/DALGO-1625) | Replaces the crowded advanced-per-table layout with a right-side settings inspector. Incremental, Destination, Cursor field and Primary key now have clear descriptions. Columns expands downward inside the inspector and the first table is initialized for expansion while later tables remain manual. | Open **Ingest**, create or edit a connection, and click **Open settings** beside a selected table. Confirm the inspector opens on the right, its controls update when another table is chosen, Columns expands downward, and closing it returns to the empty inspector state. |
| [DALGO-1649](https://linear.app/dalgo/issue/DALGO-1649) | Removes the need to squeeze every advanced field into the table. Sync appears only in the left table; advanced controls live only in the inspector. | Open a connection with several tables. Confirm the left table remains readable without horizontal compression, Sync works there, and no second Sync control appears in the inspector. |
| Google Sheets casting | Preserves Dalgo's existing source-gated post-sync casting. Google Sheets column details show detected types and a **Cast to** selector; unsupported sources show Column and Type without casting. | Open a Google Sheets connection, choose **Open settings**, expand **Columns**, and confirm **Cast to** is available. Repeat with a non-Google-Sheets source and confirm the casting selector is absent. |
| Usability and accessibility | Adds active-row styling, spoken control names, disabled/read-only behavior, plain-language setting descriptions, independent inspector scrolling, and analytics for opening table settings. | Use keyboard navigation to open/close settings and expand Columns. In View mode, confirm settings can be inspected but mutation controls remain disabled. |

## Validation

- Focused Jest: **5 suites, 34 tests passed**
- Focused backend preference tests: **24 passed**
- Prettier: **passed**
- `git diff --check`: **passed**
- Scoped ESLint: **0 errors**; 10 existing complexity/legacy warnings

