### PR TITLE
fix(charts): make table charts usable on mobile

### DIFF
--- a/components/charts/TableChart.tsx
+++ b/components/charts/TableChart.tsx
@@ -25,10 +25,28 @@ import { formatNumber, formatDate, type NumberFormat, type DateFormat } from '@/
 import { getTableTheme } from './types/table/constants';
 import { useTableSearch } from './hooks/useTableSearch';
 import { TableSearchBar } from './TableSearchBar';
+import { useResizeObserver } from '@/hooks/useResizeObserver';
+import { useIsMobile } from '@/hooks/use-mobile';
 import type { ConditionalFormattingRule } from './types/table/types';
 
 // URL detection pattern - matches http://, https://, and www. prefixed URLs
 const URL_PATTERN = /^(https?:\/\/|www\.)/i;
+
+/**
+ * Container width (in px) below which the table switches to its narrow layout.
+ * The pagination footer alone needs ~300px for the "Showing X to Y of Z rows" text
+ * plus the page-size select, so below this the controls crush or overflow. This
+ * catches both phone viewports and narrow chart cells on a desktop dashboard.
+ */
+const NARROW_TABLE_WIDTH_PX = 480;
+
+/**
+ * Max width (in px) of a single cell in narrow layout. Without a cap, cells never
+ * truncate (the base table sets `whitespace-nowrap`) and the table's intrinsic width
+ * grows past 1500px, so users scrub sideways through a tiny window. ~140px keeps
+ * 2-3 columns visible on a 360px phone screen; full values stay available via `title`.
+ */
+const NARROW_CELL_MAX_WIDTH_PX = 140;
 
 /**
  * Check if a value is a valid URL that should be rendered as a clickable link
@@ -38,6 +56,24 @@ function isValidUrl(value: any): boolean {
     return false;
   }
   return URL_PATTERN.test(value.trim());
+}
+
+/**
+ * Caps a cell's content width in narrow layout so the column stops growing with its
+ * longest value. The clamp lives on an inner block element rather than on the `<td>`
+ * itself because `max-width` on a table cell is only a hint under `table-layout: auto`
+ * — browsers still widen the column to fit the content. On desktop this renders the
+ * children untouched (no extra element), so the desktop DOM is unchanged.
+ */
+function NarrowCellClamp({ isNarrow, children }: { isNarrow: boolean; children: React.ReactNode }) {
+  if (!isNarrow) {
+    return <>{children}</>;
+  }
+  return (
+    <div className="truncate" style={{ maxWidth: NARROW_CELL_MAX_WIDTH_PX }}>
+      {children}
+    </div>
+  );
 }
 
 /**
@@ -120,6 +156,17 @@ export function TableChart({
   // Resolve color theme
   const theme = useMemo(() => getTableTheme(config.theme), [config.theme]);
 
+  // --- Narrow (mobile / small chart cell) layout detection ---
+  // Container-based, because a chart cell on a desktop dashboard can be just as narrow
+  // as a phone. `width` is 0 until the ResizeObserver has measured, so fall back to the
+  // viewport check for the first paint (and for any container we fail to measure).
+  const { ref: containerRef, width: containerWidth } = useResizeObserver<HTMLDivElement>();
+  const isMobileViewport = useIsMobile();
+  const isNarrow = containerWidth > 0 ? containerWidth < NARROW_TABLE_WIDTH_PX : isMobileViewport;
+
+  // Pagination buttons grow to a 40px touch target in narrow layout; desktop keeps 32px.
+  const paginationButtonClass = isNarrow ? 'h-10 w-10' : 'h-8 w-8';
+
   // Determine if we're using server-side pagination (pagination prop provided) or fallback to client-side
   const isServerSidePagination = !!pagination;
 
@@ -137,6 +184,12 @@ export function TableChart({
     }
     return [];
   }, [data, table_columns]);
+
+  // Freeze the first column whenever the builder asked for it, and always in narrow layout:
+  // horizontal scrolling is the only way to read a table on a phone, and without a frozen
+  // first column the row identifier scrolls out of view. Skipped for single-column tables,
+  // where a sticky column would just eat the whole width.
+  const freezeFirstColumn = (isNarrow && columns.length > 1) || !!config.freezeFirstColumn;
 
   // Calculate paginated data
   const paginatedData = useMemo(() => {
@@ -362,9 +415,14 @@ export function TableChart({
     onSort(column, newDirection);
   };
 
-  // Handle loading state
+  // Loading / error / empty states render inside the same wrapper as the table (below)
+  // rather than returning early, so the ResizeObserver ref stays attached to a mounted
+  // node. The hook observes once on mount; an early return here would leave it with
+  // nothing to measure and the narrow layout would never activate after data arrives.
+  let stateContent: React.ReactNode = null;
+
   if (isLoading) {
-    return (
+    stateContent = (
       <div className="relative w-full h-full min-h-[300px]">
         <div className="absolute inset-0 flex items-center justify-center">
           <div className="text-center">
@@ -374,11 +432,8 @@ export function TableChart({
         </div>
       </div>
     );
-  }
-
-  // Handle error state
-  if (error) {
-    return (
+  } else if (error) {
+    stateContent = (
       <div className="relative h-full">
         <div className="absolute top-0 left-0 right-0 z-10 p-4">
           <Alert variant="warning">
@@ -391,10 +446,8 @@ export function TableChart({
         </div>
       </div>
     );
-  }
-
-  if (!data || data.length === 0) {
-    return (
+  } else if (!data || data.length === 0) {
+    stateContent = (
       <div className="flex items-center justify-center h-full p-8">
         <div className="text-center text-muted-foreground">
           <p>No data available</p>
@@ -402,10 +455,8 @@ export function TableChart({
         </div>
       </div>
     );
-  }
-
-  if (columns.length === 0) {
-    return (
+  } else if (columns.length === 0) {
+    stateContent = (
       <div className="flex items-center justify-center h-full p-8">
         <div className="text-center text-muted-foreground">
           <p>No columns configured</p>
@@ -415,8 +466,19 @@ export function TableChart({
     );
   }
 
+  // Both this return and the one below use an identical root <div>, so React reuses the
+  // same DOM node when the table swaps from loading to data — which is what keeps the
+  // ResizeObserver attached across that transition.
+  if (stateContent) {
+    return (
+      <div ref={containerRef} className="w-full h-full flex flex-col" data-testid="table-chart">
+        {stateContent}
+      </div>
+    );
+  }
+
   return (
-    <div className="w-full h-full flex flex-col">
+    <div ref={containerRef} className="w-full h-full flex flex-col" data-testid="table-chart">
       {/* Search bar */}
       <div className="flex-shrink-0 py-1 mb-2">
         <TableSearchBar
@@ -438,8 +500,9 @@ export function TableChart({
                 return (
                   <TableHead
                     key={column}
+                    title={isNarrow ? column : undefined}
                     className={`font-semibold py-2 px-2 ${getAlignmentClass(column, data[0]?.[column])} ${
-                      config.freezeFirstColumn && columns.indexOf(column) === 0
+                      freezeFirstColumn && columns.indexOf(column) === 0
                         ? 'sticky left-0 z-10 border-r shadow-[2px_0_4px_-2px_rgba(0,0,0,0.1)]'
                         : ''
                     }`}
@@ -449,25 +512,29 @@ export function TableChart({
                       borderColor: theme.border,
                     }}
                   >
-                    {canSort ? (
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        className="h-auto p-0 font-semibold hover:bg-transparent"
-                        onClick={() => handleSort(column)}
-                      >
-                        <span className="mr-1">{column}</span>
-                        {sortDirection === 'asc' ? (
-                          <ChevronUp className="h-3 w-3" />
-                        ) : sortDirection === 'desc' ? (
-                          <ChevronDown className="h-3 w-3" />
-                        ) : (
-                          <div className="h-3 w-3" />
-                        )}
-                      </Button>
-                    ) : (
-                      column
-                    )}
+                    <NarrowCellClamp isNarrow={isNarrow}>
+                      {canSort ? (
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          className={`font-semibold hover:bg-transparent ${
+                            isNarrow ? 'h-auto min-h-10 max-w-full p-0' : 'h-auto p-0'
+                          }`}
+                          onClick={() => handleSort(column)}
+                        >
+                          <span className={`mr-1 ${isNarrow ? 'truncate' : ''}`}>{column}</span>
+                          {sortDirection === 'asc' ? (
+                            <ChevronUp className="h-3 w-3" />
+                          ) : sortDirection === 'desc' ? (
+                            <ChevronDown className="h-3 w-3" />
+                          ) : (
+                            <div className="h-3 w-3" />
+                          )}
+                        </Button>
+                      ) : (
+                        column
+                      )}
+                    </NarrowCellClamp>
                   </TableHead>
                 );
               })}
@@ -494,15 +561,14 @@ export function TableChart({
                     if (isLink) {
                       const href = normalizeUrl(rawValue);
                       const linkAlignClass = getAlignmentClass(column, rawValue);
-                      const isLinkFrozen =
-                        config.freezeFirstColumn && columns.indexOf(column) === 0;
+                      const isLinkFrozen = freezeFirstColumn && columns.indexOf(column) === 0;
                       const linkColIdx = columns.indexOf(column);
 
                       return (
                         <TableCell
                           key={column}
                           data-search-cell={`${index}-${linkColIdx}`}
-                          className={`py-1.5 px-2 ${linkAlignClass} ${
+                          className={`px-2 ${isNarrow ? 'py-2.5' : 'py-1.5'} ${linkAlignClass} ${
                             isLinkFrozen
                               ? 'sticky left-0 z-10 border-r shadow-[2px_0_4px_-2px_rgba(0,0,0,0.1)]'
                               : ''
@@ -529,7 +595,7 @@ export function TableChart({
                     const cellValue = formatCellValue(rawValue, column);
                     const conditionalColor = getConditionalColor(rawValue, column);
                     const alignClass = getAlignmentClass(column, rawValue);
-                    const isFrozen = config.freezeFirstColumn && columns.indexOf(column) === 0;
+                    const isFrozen = freezeFirstColumn && columns.indexOf(column) === 0;
                     const colIdx = columns.indexOf(column);
                     const matchHighlight = isSearchMatch(index, colIdx);
 
@@ -548,7 +614,9 @@ export function TableChart({
                       <TableCell
                         key={column}
                         data-search-cell={`${index}-${colIdx}`}
-                        className={`py-1.5 px-2 ${alignClass} ${
+                        // Full value stays reachable when the cell is truncated
+                        title={isNarrow ? String(cellValue) : undefined}
+                        className={`px-2 ${isNarrow ? 'py-2.5' : 'py-1.5'} ${alignClass} ${
                           isDrillDownClickable
                             ? 'text-blue-600 hover:text-blue-800 hover:underline cursor-pointer'
                             : ''
@@ -566,7 +634,7 @@ export function TableChart({
                             : undefined
                         }
                       >
-                        {cellValue}
+                        <NarrowCellClamp isNarrow={isNarrow}>{cellValue}</NarrowCellClamp>
                       </TableCell>
                     );
                   })}
@@ -579,76 +647,91 @@ export function TableChart({
 
       {/* Pagination Controls */}
       {(isServerSidePagination ? (pagination?.total || 0) > 0 : data.length > 0) && (
-        <div className="flex items-center justify-between border-t px-4 py-3">
-          <div className="flex items-center gap-6">
-            <div className="flex items-center gap-2">
-              <span className="text-sm text-muted-foreground">
-                {isServerSidePagination ? (
-                  <>
-                    Showing {(pagination!.page - 1) * pagination!.pageSize + 1} to{' '}
-                    {Math.min(pagination!.page * pagination!.pageSize, pagination!.total)} of{' '}
-                    {pagination!.total.toLocaleString()} rows
-                  </>
-                ) : (
-                  <>
-                    Showing {(currentPage - 1) * pageSize + 1} to{' '}
-                    {Math.min(currentPage * pageSize, data.length)} of{' '}
-                    {data.length.toLocaleString()} rows
-                  </>
-                )}
-              </span>
-              {(isServerSidePagination ? pagination?.onPageSizeChange : true) && (
-                <Select
-                  value={
-                    isServerSidePagination ? pagination!.pageSize.toString() : pageSize.toString()
-                  }
-                  onValueChange={(value) => {
-                    const newPageSize = parseInt(value);
-                    if (isServerSidePagination) {
-                      pagination?.onPageSizeChange?.(newPageSize);
-                    } else {
-                      setPageSize(newPageSize);
-                      setCurrentPage(1);
+        <div
+          className={`flex flex-wrap items-center gap-2 border-t ${
+            isNarrow ? 'justify-center px-2 py-2' : 'justify-between px-4 py-3'
+          }`}
+          data-testid="table-pagination-footer"
+        >
+          {/* Row-count text and page-size picker need ~300px; they are dropped in narrow
+              layout so the prev/next controls stay usable instead of overflowing. */}
+          {!isNarrow && (
+            <div className="flex items-center gap-6">
+              <div className="flex items-center gap-2">
+                <span className="text-sm text-muted-foreground">
+                  {isServerSidePagination ? (
+                    <>
+                      Showing {(pagination!.page - 1) * pagination!.pageSize + 1} to{' '}
+                      {Math.min(pagination!.page * pagination!.pageSize, pagination!.total)} of{' '}
+                      {pagination!.total.toLocaleString()} rows
+                    </>
+                  ) : (
+                    <>
+                      Showing {(currentPage - 1) * pageSize + 1} to{' '}
+                      {Math.min(currentPage * pageSize, data.length)} of{' '}
+                      {data.length.toLocaleString()} rows
+                    </>
+                  )}
+                </span>
+                {(isServerSidePagination ? pagination?.onPageSizeChange : true) && (
+                  <Select
+                    value={
+                      isServerSidePagination ? pagination!.pageSize.toString() : pageSize.toString()
                     }
-                  }}
-                >
-                  <SelectTrigger className="h-8 w-[70px]">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="10">10</SelectItem>
-                    <SelectItem value="20">20</SelectItem>
-                    <SelectItem value="50">50</SelectItem>
-                    <SelectItem value="100">100</SelectItem>
-                    <SelectItem value="200">200</SelectItem>
-                  </SelectContent>
-                </Select>
-              )}
+                    onValueChange={(value) => {
+                      const newPageSize = parseInt(value);
+                      if (isServerSidePagination) {
+                        pagination?.onPageSizeChange?.(newPageSize);
+                      } else {
+                        setPageSize(newPageSize);
+                        setCurrentPage(1);
+                      }
+                    }}
+                  >
+                    <SelectTrigger className="h-8 w-[70px]" data-testid="table-page-size-select">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="10">10</SelectItem>
+                      <SelectItem value="20">20</SelectItem>
+                      <SelectItem value="50">50</SelectItem>
+                      <SelectItem value="100">100</SelectItem>
+                      <SelectItem value="200">200</SelectItem>
+                    </SelectContent>
+                  </Select>
+                )}
+              </div>
             </div>
-          </div>
+          )}
 
           <div className="flex items-center gap-2">
             <div className="flex items-center gap-1">
+              {/* First/last jumps are dropped in narrow layout — prev/next cover the
+                  common case and every button here has to fit on one row. */}
+              {!isNarrow && (
+                <Button
+                  variant="outline"
+                  size="icon"
+                  className={paginationButtonClass}
+                  data-testid="table-pagination-first-btn"
+                  onClick={() => {
+                    if (isServerSidePagination) {
+                      pagination?.onPageChange(1);
+                    } else {
+                      setCurrentPage(1);
+                    }
+                  }}
+                  disabled={isServerSidePagination ? pagination!.page === 1 : currentPage === 1}
+                >
+                  <ChevronFirst className="h-4 w-4" />
+                  <span className="sr-only">First page</span>
+                </Button>
+              )}
               <Button
                 variant="outline"
                 size="icon"
-                className="h-8 w-8"
-                onClick={() => {
-                  if (isServerSidePagination) {
-                    pagination?.onPageChange(1);
-                  } else {
-                    setCurrentPage(1);
-                  }
-                }}
-                disabled={isServerSidePagination ? pagination!.page === 1 : currentPage === 1}
-              >
-                <ChevronFirst className="h-4 w-4" />
-                <span className="sr-only">First page</span>
-              </Button>
-              <Button
-                variant="outline"
-                size="icon"
-                className="h-8 w-8"
+                className={paginationButtonClass}
+                data-testid="table-pagination-prev-btn"
                 onClick={() => {
                   if (isServerSidePagination) {
                     pagination?.onPageChange(pagination.page - 1);
@@ -664,7 +747,7 @@ export function TableChart({
             </div>
 
             <div className="flex items-center gap-1">
-              <span className="text-sm font-medium">
+              <span className="text-sm font-medium" data-testid="table-pagination-page-indicator">
                 Page {isServerSidePagination ? pagination!.page : currentPage} of {totalPages}
               </span>
             </div>
@@ -673,7 +756,8 @@ export function TableChart({
               <Button
                 variant="outline"
                 size="icon"
-                className="h-8 w-8"
+                className={paginationButtonClass}
+                data-testid="table-pagination-next-btn"
                 onClick={() => {
                   if (isServerSidePagination) {
                     pagination?.onPageChange(pagination.page + 1);
@@ -690,26 +774,29 @@ export function TableChart({
                 <ChevronRight className="h-4 w-4" />
                 <span className="sr-only">Next page</span>
               </Button>
-              <Button
-                variant="outline"
-                size="icon"
-                className="h-8 w-8"
-                onClick={() => {
-                  if (isServerSidePagination) {
-                    pagination?.onPageChange(Math.ceil(pagination.total / pagination.pageSize));
-                  } else {
-                    setCurrentPage(totalPages);
+              {!isNarrow && (
+                <Button
+                  variant="outline"
+                  size="icon"
+                  className={paginationButtonClass}
+                  data-testid="table-pagination-last-btn"
+                  onClick={() => {
+                    if (isServerSidePagination) {
+                      pagination?.onPageChange(Math.ceil(pagination.total / pagination.pageSize));
+                    } else {
+                      setCurrentPage(totalPages);
+                    }
+                  }}
+                  disabled={
+                    isServerSidePagination
+                      ? pagination!.page * pagination!.pageSize >= pagination!.total
+                      : currentPage === totalPages
                   }
-                }}
-                disabled={
-                  isServerSidePagination
-                    ? pagination!.page * pagination!.pageSize >= pagination!.total
-                    : currentPage === totalPages
-                }
-              >
-                <ChevronLast className="h-4 w-4" />
-                <span className="sr-only">Last page</span>
-              </Button>
+                >
+                  <ChevronLast className="h-4 w-4" />
+                  <span className="sr-only">Last page</span>
+                </Button>
+              )}
             </div>
           </div>
         </div>

--- a/components/charts/TableChart.tsx
+++ b/components/charts/TableChart.tsx
@@ -49,6 +49,15 @@ const NARROW_TABLE_WIDTH_PX = 480;
 const NARROW_CELL_MAX_WIDTH_PX = 140;
 
 /**
+ * Minimum container width (in px) at which freezing the first column helps. A frozen
+ * cell is ~156px wide (the clamp plus padding); in a container narrower than that it
+ * covers the entire scroll area, so scrolling right slides every other column behind
+ * it and they become unreachable. Below this width, scrolling freely beats keeping the
+ * row identifier pinned. Roughly 2x the cell clamp, so a second column stays visible.
+ */
+const MIN_WIDTH_FOR_FROZEN_COLUMN_PX = 300;
+
+/**
  * Check if a value is a valid URL that should be rendered as a clickable link
  */
 function isValidUrl(value: any): boolean {
@@ -185,11 +194,17 @@ export function TableChart({
     return [];
   }, [data, table_columns]);
 
-  // Freeze the first column whenever the builder asked for it, and always in narrow layout:
-  // horizontal scrolling is the only way to read a table on a phone, and without a frozen
-  // first column the row identifier scrolls out of view. Skipped for single-column tables,
-  // where a sticky column would just eat the whole width.
-  const freezeFirstColumn = (isNarrow && columns.length > 1) || !!config.freezeFirstColumn;
+  // Freeze the first column whenever the builder asked for it, and by default in narrow
+  // layout: horizontal scrolling is the only way to read a table on a phone, and without a
+  // frozen first column the row identifier scrolls out of view. Skipped for single-column
+  // tables and for containers too narrow to fit a frozen column plus part of a second one
+  // (containerWidth 0 means unmeasured, i.e. the phone-viewport fallback — always wide
+  // enough). An explicit chart setting is always honoured.
+  const freezeFirstColumn =
+    (isNarrow &&
+      columns.length > 1 &&
+      (containerWidth === 0 || containerWidth >= MIN_WIDTH_FOR_FROZEN_COLUMN_PX)) ||
+    !!config.freezeFirstColumn;
 
   // Calculate paginated data
   const paginatedData = useMemo(() => {

--- a/components/charts/__tests__/TableChart.mobile.test.tsx
+++ b/components/charts/__tests__/TableChart.mobile.test.tsx
@@ -27,6 +27,8 @@ jest.mock('@/hooks/use-mobile', () => ({
 const NARROW_WIDTH = 320;
 /** Width comfortably above the narrow threshold. */
 const WIDE_WIDTH = 900;
+/** A very narrow dashboard cell — too tight to fit a frozen column plus a second one. */
+const TINY_WIDTH = 150;
 
 describe('TableChart - narrow layout', () => {
   const mockData = [
@@ -95,6 +97,24 @@ describe('TableChart - narrow layout', () => {
       expect(cell(container, 0, 0)).toHaveClass('sticky');
       expect(cell(container, 0, 1)).not.toHaveClass('sticky');
       expect(screen.getByText('region').closest('th')).toHaveClass('sticky');
+    });
+
+    it('should not freeze in a container too narrow to show a second column', () => {
+      // A frozen cell is wider than the scroll area at this size, so it would cover
+      // every other column and make them unreachable — worse than no freeze at all.
+      mockContainerWidth = TINY_WIDTH;
+      const { container } = render(<TableChart data={mockData} config={config} />);
+
+      expect(cell(container, 0, 0)).not.toHaveClass('sticky');
+    });
+
+    it('should still honour an explicit freeze setting in a very narrow container', () => {
+      mockContainerWidth = TINY_WIDTH;
+      const { container } = render(
+        <TableChart data={mockData} config={{ ...config, freezeFirstColumn: true }} />
+      );
+
+      expect(cell(container, 0, 0)).toHaveClass('sticky');
     });
 
     it('should not freeze a single-column table when narrow', () => {

--- a/components/charts/__tests__/TableChart.mobile.test.tsx
+++ b/components/charts/__tests__/TableChart.mobile.test.tsx
@@ -1,0 +1,201 @@
+/**
+ * TableChart narrow-layout (mobile / small chart cell) tests.
+ *
+ * jsdom has no layout engine and stubs ResizeObserver (jest.setup.ts), so the container
+ * width is mocked here. These tests assert the layout decisions the component makes for a
+ * given width — they cannot verify the resulting visual fit, which was checked manually.
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { TableChart } from '../TableChart';
+
+// Mocked container width, driven per test. Must be `mock`-prefixed for the jest.mock factory.
+let mockContainerWidth = 0;
+const mockRef: { current: HTMLDivElement | null } = { current: null };
+jest.mock('@/hooks/useResizeObserver', () => ({
+  useResizeObserver: () => ({ ref: mockRef, width: mockContainerWidth, height: 0 }),
+}));
+
+// Viewport fallback used when the container has not been measured yet.
+let mockIsMobileViewport = false;
+jest.mock('@/hooks/use-mobile', () => ({
+  useIsMobile: () => mockIsMobileViewport,
+}));
+
+/** Width that puts the table in narrow layout (below NARROW_TABLE_WIDTH_PX). */
+const NARROW_WIDTH = 320;
+/** Width comfortably above the narrow threshold. */
+const WIDE_WIDTH = 900;
+
+describe('TableChart - narrow layout', () => {
+  const mockData = [
+    { region: 'Kutch district, Gujarat', beneficiaries: 1200, spend: 450000 },
+    { region: 'Bhavnagar district, Gujarat', beneficiaries: 900, spend: 310000 },
+  ];
+  const config = { table_columns: ['region', 'beneficiaries', 'spend'] };
+
+  beforeEach(() => {
+    mockContainerWidth = 0;
+    mockIsMobileViewport = false;
+  });
+
+  const cell = (container: HTMLElement, rowIdx: number, colIdx: number) =>
+    container.querySelector(`[data-search-cell="${rowIdx}-${colIdx}"]`) as HTMLElement;
+
+  /** The inner clamp element that caps the column width in narrow layout. */
+  const clamp = (container: HTMLElement, rowIdx: number, colIdx: number) =>
+    cell(container, rowIdx, colIdx).querySelector('div.truncate') as HTMLElement | null;
+
+  describe('Cell truncation', () => {
+    it('should clamp cell width and expose the full value via title when narrow', () => {
+      mockContainerWidth = NARROW_WIDTH;
+      const { container } = render(<TableChart data={mockData} config={config} />);
+
+      // Clamp sits on an inner block element — max-width on a <td> is ignored under
+      // table-layout: auto, which is what let the table grow past the viewport.
+      const inner = clamp(container, 0, 0);
+      expect(inner).not.toBeNull();
+      expect(inner!.style.maxWidth).toBe('140px');
+      expect(cell(container, 0, 0)).toHaveAttribute('title', 'Kutch district, Gujarat');
+    });
+
+    it('should not clamp or add titles at desktop width', () => {
+      mockContainerWidth = WIDE_WIDTH;
+      const { container } = render(<TableChart data={mockData} config={config} />);
+
+      expect(clamp(container, 0, 0)).toBeNull();
+      expect(cell(container, 0, 0)).not.toHaveAttribute('title');
+    });
+
+    it('should fall back to the mobile viewport check before the container is measured', () => {
+      mockContainerWidth = 0;
+      mockIsMobileViewport = true;
+      const { container } = render(<TableChart data={mockData} config={config} />);
+
+      expect(clamp(container, 0, 0)).not.toBeNull();
+    });
+
+    it('should stay in desktop layout when unmeasured on a desktop viewport', () => {
+      mockContainerWidth = 0;
+      mockIsMobileViewport = false;
+      const { container } = render(<TableChart data={mockData} config={config} />);
+
+      expect(clamp(container, 0, 0)).toBeNull();
+    });
+  });
+
+  describe('Frozen first column', () => {
+    it('should freeze the first column when narrow even if the chart config disables it', () => {
+      mockContainerWidth = NARROW_WIDTH;
+      const { container } = render(
+        <TableChart data={mockData} config={{ ...config, freezeFirstColumn: false }} />
+      );
+
+      expect(cell(container, 0, 0)).toHaveClass('sticky');
+      expect(cell(container, 0, 1)).not.toHaveClass('sticky');
+      expect(screen.getByText('region').closest('th')).toHaveClass('sticky');
+    });
+
+    it('should not freeze a single-column table when narrow', () => {
+      mockContainerWidth = NARROW_WIDTH;
+      const { container } = render(
+        <TableChart data={mockData} config={{ table_columns: ['region'] }} />
+      );
+
+      expect(cell(container, 0, 0)).not.toHaveClass('sticky');
+    });
+
+    it('should keep honouring the chart config at desktop width', () => {
+      mockContainerWidth = WIDE_WIDTH;
+      const { container, rerender } = render(
+        <TableChart data={mockData} config={{ ...config, freezeFirstColumn: false }} />
+      );
+      expect(cell(container, 0, 0)).not.toHaveClass('sticky');
+
+      rerender(<TableChart data={mockData} config={{ ...config, freezeFirstColumn: true }} />);
+      expect(cell(container, 0, 0)).toHaveClass('sticky');
+    });
+  });
+
+  describe('Pagination footer', () => {
+    const manyRows = Array.from({ length: 50 }, (_, i) => ({
+      region: `Region ${i + 1}`,
+      beneficiaries: i * 10,
+    }));
+    const manyRowsConfig = { table_columns: ['region', 'beneficiaries'] };
+
+    it('should drop the row-count text, page-size select and first/last jumps when narrow', () => {
+      mockContainerWidth = NARROW_WIDTH;
+      render(<TableChart data={manyRows} config={manyRowsConfig} />);
+
+      expect(screen.queryByText(/showing 1 to 10 of 50 rows/i)).not.toBeInTheDocument();
+      expect(screen.queryByTestId('table-page-size-select')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('table-pagination-first-btn')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('table-pagination-last-btn')).not.toBeInTheDocument();
+    });
+
+    it('should keep prev/next and the page indicator when narrow', () => {
+      mockContainerWidth = NARROW_WIDTH;
+      render(<TableChart data={manyRows} config={manyRowsConfig} />);
+
+      expect(screen.getByTestId('table-pagination-prev-btn')).toBeInTheDocument();
+      expect(screen.getByTestId('table-pagination-next-btn')).toBeInTheDocument();
+      expect(screen.getByTestId('table-pagination-page-indicator')).toHaveTextContent(
+        'Page 1 of 5'
+      );
+    });
+
+    it('should use 40px touch targets when narrow and 32px on desktop', () => {
+      mockContainerWidth = NARROW_WIDTH;
+      const { rerender } = render(<TableChart data={manyRows} config={manyRowsConfig} />);
+      expect(screen.getByTestId('table-pagination-next-btn')).toHaveClass('h-10', 'w-10');
+
+      mockContainerWidth = WIDE_WIDTH;
+      rerender(<TableChart data={[...manyRows]} config={manyRowsConfig} />);
+      expect(screen.getByTestId('table-pagination-next-btn')).toHaveClass('h-8', 'w-8');
+    });
+
+    it('should wrap instead of overflowing', () => {
+      mockContainerWidth = NARROW_WIDTH;
+      render(<TableChart data={manyRows} config={manyRowsConfig} />);
+
+      expect(screen.getByTestId('table-pagination-footer')).toHaveClass('flex-wrap');
+    });
+
+    it('should keep the full desktop footer above the narrow threshold', () => {
+      mockContainerWidth = WIDE_WIDTH;
+      render(<TableChart data={manyRows} config={manyRowsConfig} />);
+
+      expect(screen.getByText(/showing 1 to 10 of 50 rows/i)).toBeInTheDocument();
+      expect(screen.getByTestId('table-page-size-select')).toBeInTheDocument();
+      expect(screen.getByTestId('table-pagination-first-btn')).toBeInTheDocument();
+      expect(screen.getByTestId('table-pagination-last-btn')).toBeInTheDocument();
+    });
+  });
+
+  describe('Search bar', () => {
+    it('should still render when narrow', () => {
+      mockContainerWidth = NARROW_WIDTH;
+      render(<TableChart data={mockData} config={config} />);
+
+      expect(screen.getByTestId('table-search-bar')).toBeInTheDocument();
+      expect(screen.getByTestId('table-search-input')).toBeInTheDocument();
+    });
+  });
+
+  describe('Container measurement across states', () => {
+    it('should keep the measured wrapper mounted while loading so the observer stays attached', () => {
+      const { rerender } = render(<TableChart data={[]} isLoading={true} />);
+      const wrapperWhileLoading = screen.getByTestId('table-chart');
+      expect(screen.getByText('Loading table data...')).toBeInTheDocument();
+
+      mockContainerWidth = NARROW_WIDTH;
+      rerender(<TableChart data={mockData} config={config} isLoading={false} />);
+
+      // Same DOM node reused → the ResizeObserver attached on mount keeps measuring.
+      expect(screen.getByTestId('table-chart')).toBe(wrapperWhileLoading);
+      expect(screen.getByRole('table')).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Table charts were unusable on phones during dashboard demos at a partner NGO (AKRSP).

Root cause in `components/charts/TableChart.tsx`: the table is wrapped in `overflow-auto`, but cells inherit `whitespace-nowrap` from `components/ui/table.tsx` and nothing truncates. A table with a handful of text columns has an intrinsic width well past 1500px, so on a ~350px screen users scrub sideways through a tiny window — and because `freezeFirstColumn` defaults to `false`, the row identifier scrolls out of view as soon as they do. The pagination footer made it worse: `flex items-center justify-between` with no `flex-wrap`, holding ~250-300px of irreducible content ("Showing X to Y of Z rows", a `w-[70px]` page-size select, four icon buttons, "Page N of M").

This affects every dashboard view path — private, public, share and embed (`chart-element-view.tsx`) as well as the builder (`chart-element-v2.tsx`) — since `TableChart` is the single renderer for `chart_type === 'table'`.

### What changed

`TableChart` now switches into a **narrow layout** below a 480px container width. Detection is **container-based** (`hooks/useResizeObserver.ts`) rather than viewport-based, because a chart cell on a *desktop* dashboard can be just as narrow as a phone; `hooks/use-mobile.ts` (`useIsMobile`) is the fallback for the first paint, before the ResizeObserver has measured. Desktop rendering is unchanged.

1. **Cell truncation** — cell and header content is clamped to 140px and truncated with an ellipsis, with the full value available on the native `title` attribute. The clamp sits on an inner block element, not the `<td>`: `max-width` on a table cell is only a hint under `table-layout: auto`.
2. **Sticky first column on by default when narrow** — the existing freeze-first-column behaviour is turned on regardless of the builder setting, so the row identifier stays visible while scrolling right. Desktop keeps the configured setting, and an explicit setting is always honoured. Two exceptions where auto-freeze would backfire: single-column tables, and containers under 300px — a frozen cell is ~156px wide, so in a ~112px dashboard cell it covers the whole scroll area and every other column becomes permanently unreachable (measured, see below).
3. **Compact, wrappable pagination** — the footer gets `flex-wrap` unconditionally (helps narrow desktop cells too). When narrow it drops the row-count text, the page-size select and the first/last jumps, keeps prev / "Page N of M" / next, and grows the buttons to 40px touch targets.
4. **Search input** — unchanged; verified it already flexes to full width and does not break the narrow layout.

All three thresholds are named constants with comments explaining the value. New interactive elements carry `data-testid`. No new user actions, so **no new analytics events** — flagging that explicitly since instrumentation is normally a review blocker.

`components/ui/table.tsx` was **not** modified; everything is overridden from within `TableChart`.

## Test Plan

**Unit tests** — new `components/charts/__tests__/TableChart.mobile.test.tsx` (16 tests) covering truncation on/off, the viewport fallback before measurement, auto-freeze when narrow, the single-column and too-narrow exceptions, the explicit-setting override, the desktop config path, the narrow vs desktop footer contents, 40px touch targets, `flex-wrap`, the search bar, and that the measured wrapper stays mounted across the loading → data transition (an early return there would have detached the ResizeObserver and made the whole fix a silent no-op).

```
npx jest components/charts/__tests__/TableChart
  TableChart.test.tsx         17 passed  (pre-existing, unchanged, no assertions weakened)
  TableChart.mobile.test.tsx  16 passed  (new)
  Tests: 33 passed, 33 total

npx jest components/charts components/dashboard
  Test Suites: 45 passed, 1 failed (46)
  Tests:      608 passed, 2 failed (610)
```

The 2 failures are in `components/charts/__tests__/DataPreview.test.tsx` and are **pre-existing on `main`** — verified by stashing this branch's changes and re-running; `DataPreview` does not import `TableChart`.

```
npm run lint     0 errors (warnings are pre-existing: `any` usage and max-lines-per-function)
npx tsc --noEmit 0 errors in the changed files
```

**Layout verification** — the truncation mechanism was measured in real Chrome (Playwright, 390px viewport) against markup mirroring `components/ui/table.tsx`:

| | table width | first column |
|---|---|---|
| before (no clamp) | 689px | 193px, second column cut mid-word |
| after (inner clamp) | 572px | 156px, clean ellipsis |

The same harness caught the frozen-column regression above: in a 112px container scrolled fully right, the frozen variant leaves 0px of any other column visible (the sticky cell spans the entire 108px scrollport), while the unfrozen variant still shows 105px of the last column. Hence the 300px floor on auto-freeze.

**Not verified end-to-end in the running app** — the fix was not loaded in a browser against a real dashboard at 375px. jsdom has no layout engine, so the unit tests assert the layout *decisions* for a given width, not the resulting visual fit. Worth one manual pass on a phone before merge.

**Known cosmetic limitation** — a long *column name* in narrow layout is hard-clipped rather than ellipsized: the `truncate` span sits inside the sort `Button`'s `inline-flex` without `min-w-0`, so the clamp's `overflow: hidden` does the cutting and the sort chevron can be clipped too. Sorting still works and the full name is on the `<th>`'s `title`. Left for a follow-up.

## Out of scope (follow-ups)

- **Dashboard grid stacking** — `dashboard-native-view.tsx` uses a 12-column grid at *every* breakpoint, so a chart configured 3 columns wide stays 3/12 of the screen on a phone (~90px) instead of stacking to full width. That is the deeper reason charts are unreadable on mobile; this PR only makes the table survive a narrow cell. Fixing it means adding responsive breakpoint layouts to the grid config, which changes saved dashboard layouts — a separate PR.
- The hover-gated fullscreen toolbar (unreachable on touch), `PivotTableChart` (same truncation problem, separate renderer), and `components/ui/table.tsx` itself.
- `TableChart.tsx` is still on the legacy chart path, not the `components/charts/types/<type>/` registry (`rules/charts.md`); this change will need to move with it when table is migrated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
